### PR TITLE
Allow using nettle instead of libgcrypt for MD5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - sudo apt-get update -qq
 install:
   - sudo apt-get install libcap-dev -qq
+  - sudo apt-get install nettle-dev -qq
   # gcc
   - if [ "$CC" = "gcc-4.8" ]; then sudo apt-get install -qq gcc-4.8; fi
   # clang

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LDFLAG_STATIC=-Wl,-Bstatic
 LDFLAG_DYNAMIC=-Wl,-Bdynamic
 LDFLAG_CAP=-lcap
 LDFLAG_GCRYPT=-lgcrypt
+LDFLAG_NETTLE=-lnettle
 LDFLAG_CRYPTO=-lcrypto
 LDFLAG_IDN=-lidn
 LDFLAG_RESOLV=-lresolv
@@ -33,8 +34,10 @@ WITHOUT_IFADDRS=no
 # arping default device (e.g. eth0) []
 ARPING_DEFAULT_DEVICE=
 
-# GNU TLS library for ping6 [yes|no|static]
-USE_GCRYPT=yes
+# nettle library for ping6 [yes|no|static]
+USE_NETTLE=yes
+# libgcrypt library for ping6 [yes|no|static]
+USE_GCRYPT=no
 # Crypto library for ping6 [shared|static|no]
 USE_CRYPTO=shared
 # Resolv library for ping6 [yes|static]
@@ -61,9 +64,14 @@ ifneq ($(USE_GCRYPT),no)
 	LIB_CRYPTO = $(call FUNC_LIB,$(USE_GCRYPT),$(LDFLAG_GCRYPT))
 	DEF_CRYPTO = -DUSE_GCRYPT
 else
+ifneq ($(USE_NETTLE),no)
+	LIB_CRYPTO = $(call FUNC_LIB,$(USE_NETTLE),$(LDFLAG_NETTLE))
+	DEF_CRYPTO = -DUSE_NETTLE
+else
 ifneq ($(USE_CRYPTO),no)
 	LIB_CRYPTO = $(call FUNC_LIB,$(USE_CRYPTO),$(LDFLAG_CRYPTO))
 	DEF_CRYPTO = -DUSE_OPENSSL
+endif
 endif
 endif
 

--- a/iputils_md5dig.h
+++ b/iputils_md5dig.h
@@ -1,15 +1,17 @@
 #ifndef IPUTILS_MD5DIG_H
 #define IPUTILS_MD5DIG_H
 
-#ifdef USE_GCRYPT
+#if defined(USE_GCRYPT)
 # include <stdlib.h>
 # include <gcrypt.h>
 # define IPUTILS_MD5DIG_LEN	16
+#elif defined(USE_NETTLE)
+# include <nettle/md5.h>
 #else
 # include <openssl/md5.h>
 #endif
 
-#ifdef USE_GCRYPT
+#if defined(USE_GCRYPT)
 typedef struct {
 	gcry_md_hd_t dig;
 } iputils_md5dig_ctx;
@@ -50,5 +52,34 @@ static void iputils_md5dig_final(unsigned char *digest,
 # define MD5_Init		iputils_md5dig_init
 # define MD5_Update		iputils_md5dig_update
 # define MD5_Final		iputils_md5dig_final
+
+#elif defined(USE_NETTLE)
+typedef struct md5_ctx iputils_md5dig_ctx;
+
+static void iputils_md5dig_init(iputils_md5dig_ctx *ctx)
+{
+	md5_init(ctx);
+	return;
+}
+
+static void iputils_md5dig_update(iputils_md5dig_ctx *ctx,
+			   void *buf, int len)
+{
+	md5_update(ctx, len, buf);
+	return;
+}
+
+static void iputils_md5dig_final(unsigned char *digest,
+				 iputils_md5dig_ctx *ctx)
+{
+	md5_digest(ctx, MD5_DIGEST_SIZE, digest);
+}
+
+# define MD5_DIGEST_LENGTH	MD5_DIGEST_SIZE
+# define MD5_CTX		iputils_md5dig_ctx
+# define MD5_Init		iputils_md5dig_init
+# define MD5_Update		iputils_md5dig_update
+# define MD5_Final		iputils_md5dig_final
 #endif
+
 #endif

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -160,7 +160,7 @@ struct sockaddr_in6 source;
 char *device;
 int pmtudisc=-1;
 
-#if defined(USE_GNUTLS) || defined(USE_OPENSSL)
+#if defined(USE_GCRYPT) || defined(USE_OPENSSL) || defined(USE_NETTLE)
 #include "iputils_md5dig.h"
 #define USE_CRYPTO
 #endif


### PR DESCRIPTION
nettle is simpler library, and doesn't require any explicit global initialization as libgcrypt does.