### PR TITLE
ping: always use POSIX locale when parsing -i

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -259,7 +259,13 @@ main(int argc, char **argv)
 			char *ep;
 
 			errno = 0;
+#ifdef USE_IDN
+			setlocale(LC_ALL, "C");
+#endif
 			dbl = strtod(optarg, &ep);
+#ifdef USE_IDN
+			setlocale(LC_ALL, "");
+#endif
 
 			if (errno || *ep != '\0' ||
 				!finite(dbl) || dbl < 0.0 || dbl >= (double)INT_MAX / 1000 - 1.0) {


### PR DESCRIPTION
Interpreting floating-point numbers from the command line based on the
current locale is a bad idea.

Original bugreport: https://bugzilla.redhat.com/show_bug.cgi?id=1283277