### PR TITLE
'admin prohibited' should print !X not !S.

### DIFF
--- a/traceroute6.c
+++ b/traceroute6.c
@@ -165,7 +165,8 @@
  * Other possible annotations after the time are !H, !N, !P (got a host,
  * network or protocol unreachable, respectively), !S or !F (source
  * route failed or fragmentation needed -- neither of these should
- * ever occur and the associated gateway is busted if you see one).  If
+ * ever occur and the associated gateway is busted if you see one),
+ * !X (communication administratively prohibited). If
  * almost all the probes result in some kind of unreachable, traceroute
  * will give up and exit.
  *
@@ -632,7 +633,7 @@ int main(int argc, char *argv[])
 
 					case ICMP6_DST_UNREACH_ADMIN:
 						++unreachable;
-						Printf(" !S");
+						Printf(" !X");
 						break;
 					}
 					break;


### PR DESCRIPTION
The linux (at least) manpage says:
After the trip time, some additional annotation can be printed: !H, !N, or !P (host, network or protocol unreachable), !S (source route failed), !F (fragmentation needed), !X (communication administratively prohibited), !V (host precedence violation), !C (precedence cutoff in effect), or !<num> (ICMP unreachable code <num>). If almost all the probes result in some kind of unreachable, traceroute will give up and exit.

your code says: "ICMP6_DST_UNREACH_ADMIN" -> !S
you really mean !X