### PR TITLE
fix two issues observed when using -I option with IP addresses

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -279,10 +279,6 @@ main(int argc, char **argv)
 			break;
 		}
 		case 'I':
-			if (inet_pton(AF_INET, optarg, &source.sin_addr) > 0)
-				options |= F_STRICTSOURCE;
-			else
-				device = optarg;
 			/* IPv6 */
 			if (strchr(optarg, ':')) {
 				char *p, *addr = strdup(optarg);
@@ -306,6 +302,8 @@ main(int argc, char **argv)
 				options |= F_STRICTSOURCE;
 
 				free(addr);
+			} else if (inet_pton(AF_INET, optarg, &source.sin_addr) > 0) {
+				options |= F_STRICTSOURCE;
 			} else {
 				device = optarg;
 			}

--- a/ping_common.c
+++ b/ping_common.c
@@ -373,11 +373,10 @@ resend:
 	if (i > 0) {
 		/* Apparently, it is some fatal bug. */
 		abort();
-	} else if (errno == ENOBUFS || errno == ENOMEM || errno == EPERM) {
+	} else if (errno == ENOBUFS || errno == ENOMEM) {
 		int nores_interval;
 
-		/* Device queue overflow, OOM or operation not permitted.
-		 * Packet is not sent. */
+		/* Device queue overflow or OOM. Packet is not sent. */
 		tokens = 0;
 		/* Slowdown. This works only in adaptive mode (option -A) */
 		rtt_addend += (rtt < 8*50000 ? rtt/8 : 50000);
@@ -386,8 +385,7 @@ resend:
 		nores_interval = SCHINT(interval/2);
 		if (nores_interval > 500)
 			nores_interval = 500;
-		if (errno != EPERM)
-			oom_count++;
+		oom_count++;
 		if (oom_count*nores_interval < lingertime)
 			return nores_interval;
 		i = 0;


### PR DESCRIPTION
The first one is a revert of an old commit attempting to fix https://bugzilla.redhat.com/show_bug.cgi?id=1061867 but introducing other issues that is obsoleted meanwhile by a better fix from Jason A. Donenfeld <Jason@zx2c4.com>.

The second one fixes a bug in -I option parsing where device gets assigned the IP address even though it should only get assigned device names.

A bit more detailed information can be found in the respective commit messages.