### PR TITLE
tftpd: Drop supplementary groups for root

### DIFF
--- a/tftpd.c
+++ b/tftpd.c
@@ -54,6 +54,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
+#include <grp.h>
 
 #include "tftp.h"
 
@@ -101,6 +102,8 @@ int main(int ac, char **av)
 
 	/* Sanity. If parent forgot to setuid() on us. */
 	if (geteuid() == 0) {
+		/* Drop all supplementary groups. No error checking is needed */
+		setgroups(0, NULL);
 		if (setgid(65534) || setuid(65534)) {
 			syslog(LOG_ERR, "set*id failed: %m\n");
 			exit(1);


### PR DESCRIPTION
Before dropping our root privileges, we need to make sure that root
does not belong to any other group. That's because setgid() will change
the gid but it will leave the supplementary groups unchanged so we may
still be able to do privilege operations. Use setgroups() before set{u,g}id
to ensure that root does not have any unexpected priviledges.

Link: https://www.securecoding.cert.org/confluence/display/c/POS36-C.+Observe+correct+revocation+order+while+relinquishing+privileges
Signed-off-by: Markos Chandras <mchandras@suse.de>