### PR TITLE
ping: also bind the ICMP socket to the specific device

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -563,31 +563,36 @@ int ping4_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock)
 		}
 		if (device) {
 			struct ifreq ifr;
-			int rc;
+			int i;
+			int fds[2] = {probe_fd, sock->fd};
 
 			memset(&ifr, 0, sizeof(ifr));
 			strncpy(ifr.ifr_name, device, IFNAMSIZ-1);
 
-			enable_capability_raw();
-			rc = setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1);
-			disable_capability_raw();
+			for (i = 0; i < 2; i++) {
+				int fd = fds[i];
+				int rc;
+				enable_capability_raw();
+				rc = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1);
+				disable_capability_raw();
 
-			if (rc == -1) {
-				if (IN_MULTICAST(ntohl(dst.sin_addr.s_addr))) {
-					struct ip_mreqn imr;
-					if (ioctl(probe_fd, SIOCGIFINDEX, &ifr) < 0) {
-						fprintf(stderr, "ping: unknown iface %s\n", device);
+				if (rc == -1) {
+					if (IN_MULTICAST(ntohl(dst.sin_addr.s_addr))) {
+						struct ip_mreqn imr;
+						if (ioctl(fd, SIOCGIFINDEX, &ifr) < 0) {
+							fprintf(stderr, "ping: unknown iface %s\n", device);
+							exit(2);
+						}
+						memset(&imr, 0, sizeof(imr));
+						imr.imr_ifindex = ifr.ifr_ifindex;
+						if (setsockopt(fd, SOL_IP, IP_MULTICAST_IF, &imr, sizeof(imr)) == -1) {
+							perror("ping: IP_MULTICAST_IF");
+							exit(2);
+						}
+					} else {
+						perror("ping: SO_BINDTODEVICE");
 						exit(2);
 					}
-					memset(&imr, 0, sizeof(imr));
-					imr.imr_ifindex = ifr.ifr_ifindex;
-					if (setsockopt(probe_fd, SOL_IP, IP_MULTICAST_IF, &imr, sizeof(imr)) == -1) {
-						perror("ping: IP_MULTICAST_IF");
-						exit(2);
-					}
-				} else {
-					perror("ping: SO_BINDTODEVICE");
-					exit(2);
 				}
 			}
 		}

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -797,9 +797,11 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 			enable_capability_raw();
 			if (
 #ifdef IPV6_RECVPKTINFO
-			    setsockopt(probe_fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 &&
+				setsockopt(probe_fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 &&
+				setsockopt(sock->fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 &&
 #endif
-			    setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1) {
+				setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1 &&
+				setsockopt(sock->fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1) {
 				perror("setsockopt(SO_BINDTODEVICE)");
 				exit(2);
 			}


### PR DESCRIPTION
Or the default route is used. Not binding the probe_fd to the same device will result wrong source address being selected (I get a warning for this).

I've only tested for IPv4 because I don't have access to IPv6.

This closes #55.