### PR TITLE
correctly initialize first hop

### DIFF
--- a/ping6_common.c
+++ b/ping6_common.c
@@ -805,6 +805,7 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 			}
 			disable_capability_raw();
 		}
+		firsthop.sin6_family = AF_INET6;
 		firsthop.sin6_port = htons(1025);
 		if (connect(probe_fd, (struct sockaddr*)&firsthop, sizeof(firsthop)) == -1) {
 			perror("connect");


### PR DESCRIPTION
When the sin6_family was set to 0, the initial probe connect()
could have succeeded instead of failing.

Fixes #57.