### PR TITLE
fix ping -6 -I

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -106,7 +106,7 @@ static struct {
 int cmsg_len;
 
 static struct sockaddr_in source = { .sin_family = AF_INET };
-static char *device;
+char *device;
 static int pmtudisc = -1;
 
 static void create_socket(socket_st *sock, int family, int socktype, int protocol, int requisite)

--- a/ping.h
+++ b/ping.h
@@ -167,6 +167,7 @@ extern volatile int exiting;
 extern volatile int status_snapshot;
 extern int confirm;
 extern int confirm_flag;
+extern char *device;
 
 extern volatile int in_pr_addr;		/* pr_addr() is executing */
 extern jmp_buf pr_addr_jmp;


### PR DESCRIPTION
ping "passes" the device variable to ping6_common.c, but it's not visible
there.

Original patch by Xin Long <lucien.xin@gmail.com>.