### PR TITLE
arping,doc: fix documentation of -I

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -1086,7 +1086,7 @@ main(int argc, char **argv)
 			fprintf(stderr, "arping: Device %s not available.\n", device.name);
 			exit(2);
 		}
-		fprintf(stderr, "arping: device (option -I) is required.\n");
+		fprintf(stderr, "arping: Suitable device could not be determined. Please, use option -I.\n");
 		usage();
 	}
 

--- a/doc/arping.sgml
+++ b/doc/arping.sgml
@@ -19,7 +19,7 @@
 <arg choice="opt">-c <replaceable/count/</arg>
 <arg choice="opt">-w <replaceable/deadline/</arg>
 <arg choice="opt">-s <replaceable/source/</arg>
-<arg choice="req">-I <replaceable/interface/</arg>
+<arg choice="opt">-I <replaceable/interface/</arg>
 <arg choice="req"><replaceable/destination/</arg>
 </cmdsynopsis>
 </refsynopsisdiv>


### PR DESCRIPTION
Also, give a less misleading error when a device cannot be automatically
determined and has to be specified by the user using the -I option.