### PR TITLE
Add strict pattern matching on response when pattern was provided

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -1103,6 +1103,8 @@ ping4_parse_reply(struct socket_st *sock, struct msghdr *msg, int cc, void *addr
 	if (icp->type == ICMP_ECHOREPLY) {
 		if (!is_ours(sock, icp->un.echo.id))
 			return 1;			/* 'Twas not our ECHO */
+		if (!contains_pattern_in_payload((__u8*)(icp+1)))
+			return 1;			/* 'Twas really not our ECHO */
 		if (gather_statistics((__u8*)icp, sizeof(*icp), cc,
 				      ntohs(icp->un.echo.sequence),
 				      ttl, 0, tv, pr_addr(from, sizeof *from),

--- a/ping.h
+++ b/ping.h
@@ -313,6 +313,7 @@ extern ping_func_set_st ping4_func_set;
 extern int pinger(ping_func_set_st *fset, socket_st *sock);
 extern void sock_setbufs(socket_st*, int alloc);
 extern void setup(socket_st *);
+extern int contains_pattern_in_payload(__u8 *ptr);
 extern void main_loop(ping_func_set_st *fset, socket_st*, __u8 *buf, int buflen) __attribute__((noreturn));
 extern void finish(void) __attribute__((noreturn));
 extern void status(void);

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -1420,6 +1420,8 @@ ping6_parse_reply(socket_st *sock, struct msghdr *msg, int cc, void *addr, struc
 	if (icmph->icmp6_type == ICMP6_ECHO_REPLY) {
 		if (!is_ours(sock, icmph->icmp6_id))
 			return 1;
+               if (!contains_pattern_in_payload((__u8*)(icmph+1)))
+               		return 1;            /* 'Twas really not our ECHO */
 		if (gather_statistics((__u8*)icmph, sizeof(*icmph), cc,
 				      ntohs(icmph->icmp6_seq),
 				      hops, 0, tv, pr_addr(from, sizeof *from),

--- a/ping_common.c
+++ b/ping_common.c
@@ -565,6 +565,24 @@ void setup(socket_st *sock)
 	}
 }
 
+/*
+ * Return 0 if pattern in payload point to be ptr did not match the pattern that was sent  
+ */
+int contains_pattern_in_payload(__u8 *ptr)
+{
+	int i;
+	__u8 *cp, *dp;
+ 
+	/* check the data */
+	cp = ((u_char*)ptr) + sizeof(struct timeval);
+	dp = &outpack[8 + sizeof(struct timeval)];
+	for (i = sizeof(struct timeval); i < datalen; ++i, ++cp, ++dp) {
+		if (*cp != *dp)
+			return 0;
+	}
+	return 1;
+}
+
 void main_loop(ping_func_set_st *fset, socket_st *sock, __u8 *packet, int packlen)
 {
 	char addrbuf[128];


### PR DESCRIPTION
A mismatch in timeval format (for eg. between the traceroute icmp packet and ping icmp packet when id & seq are the same) could cause ping to read an arbitrarily large timeval and thus cause ping to wait for response for an arbitrarily large value of time.

In this change, if a pattern was supplied in outgoing echo request, then it is validated on the incoming echo response so that ping's icmp packets are not confused with other applications' icmp packets