### PR TITLE
ping: prevent possible double free after cap_free()

### DIFF
--- a/ping_common.c
+++ b/ping_common.c
@@ -159,6 +159,7 @@ int modify_capability(cap_value_t cap, cap_flag_value_t on)
 	}
 
 	cap_free(cap_p);
+	cap_p = NULL;
 
 	rc = 0;
 out:


### PR DESCRIPTION
Original bugreport: https://bugzilla.redhat.com/show_bug.cgi?id=1410114