### PR TITLE
Update ping_common.c

### DIFF
--- a/ping_common.c
+++ b/ping_common.c
@@ -1,4 +1,5 @@
 #include "ping.h"
+#include "float.h"
 
 #ifndef HZ
 #define HZ sysconf(_SC_CLK_TCK)
@@ -257,6 +258,7 @@ int __schedule_exit(int next)
 {
 	static unsigned long waittime;
 	struct itimerval it;
+        int deftime = 1;
 
 	if (waittime)
 		return next;
@@ -275,6 +277,10 @@ int __schedule_exit(int next)
 	it.it_interval.tv_usec = 0;
 	it.it_value.tv_sec = waittime/1000000;
 	it.it_value.tv_usec = waittime%1000000;
+	if (waittime /1000000 < DBL_EPSILON)
+	{
+	    it.it_value.tv_sec = deftime;  	
+	}
 	setitimer(ITIMER_REAL, &it, NULL);
 	return next;
 }

--- a/ping_common.c
+++ b/ping_common.c
@@ -258,7 +258,6 @@ int __schedule_exit(int next)
 {
 	static unsigned long waittime;
 	struct itimerval it;
-        int deftime = 1;
 
 	if (waittime)
 		return next;
@@ -277,10 +276,8 @@ int __schedule_exit(int next)
 	it.it_interval.tv_usec = 0;
 	it.it_value.tv_sec = waittime/1000000;
 	it.it_value.tv_usec = waittime%1000000;
-	if (waittime /1000000 < DBL_EPSILON)
-	{
-	    it.it_value.tv_sec = deftime;  	
-	}
+	if (waittime == 0)
+	    waittime = 1000; /*set a default value for waittime*/	 
 	setitimer(ITIMER_REAL, &it, NULL);
 	return next;
 }


### PR DESCRIPTION
The iputils exception handing function has not set a default time value for the struct 'itimerval it'.
in this case the tv_sec is set as 0,the setitimer will take no effect for that value. And the system
will not send a signal to itself to terminate the application.

ping '-i 0 -c' can lockup in endless loop .This script can reproduce the issue:

    ip1="fd00:a::1"
    ip2="fd00:a::2"
    m="64"

ip netns add ns1
ip link add name veth1 type veth peer name veth2
ip link set dev veth1 netns ns1
ip netns exec ns1 ip link set dev veth1 up
ip link set dev veth2 up
ip netns exec ns1 ip address add $ip1/$m dev veth1
ip add add $ip2/$m dev veth2
 ping6 -I veth2 -s 10 -i 0 $ip1 -c 30