### PR TITLE
arping: exit if network disappears while running

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -1227,6 +1227,8 @@ main(int argc, char **argv)
 		if ((cc = recvfrom(s, packet, sizeof(packet), 0,
 				   (struct sockaddr *)&from, &alen)) < 0) {
 			perror("arping: recvfrom");
+			if (errno == ENETDOWN)
+				exit(2);
 			continue;
 		}
 


### PR DESCRIPTION
Originally reported at https://bugzilla.redhat.com/show_bug.cgi?id=1387542