### PR TITLE
traceroute6: Fix use-after-free for hostname

### DIFF
--- a/traceroute6.c
+++ b/traceroute6.c
@@ -341,6 +341,7 @@ int main(int argc, char *argv[])
 	struct sockaddr_in6 from, *to;
 	int ch, i, on, probe, seq, tos, ttl;
 	int socket_errno;
+	char *resolved_hostname = NULL;
 
 	icmp_sock = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
 	socket_errno = errno;
@@ -462,7 +463,13 @@ int main(int argc, char *argv[])
 
 		memcpy(to, result->ai_addr, sizeof *to);
 		to->sin6_port = htons(port);
-		hostname = result->ai_canonname;
+		resolved_hostname = strdup(result->ai_canonname);
+		if (resolved_hostname == NULL) {
+			(void)fprintf(stderr,
+			    "traceroute: cannot allocate memory\n");
+			exit(1);
+		}
+		hostname = resolved_hostname;
 		freeaddrinfo(result);
 	}
 	firsthop = *to;
@@ -646,7 +653,11 @@ int main(int argc, char *argv[])
 		putchar('\n');
 		if (got_there ||
 		    (unreachable > 0 && unreachable >= nprobes-1))
-			exit(0);
+			break;
+	}
+
+	if (resolved_hostname != NULL) {
+		free(resolved_hostname);
 	}
 
 	return 0;


### PR DESCRIPTION
The memory pointed to by hostname is freed by freeaddrinfo so we must
copy the hostname to use it later. You can observe this when invoking
traceroute6 like 'traceroute6 www.google.com' and seeing the garbage
printed after "traceroute to ", or using ASAN.