### PR TITLE
traceroute6: Fix traceroute to IPv6 address

### DIFF
--- a/traceroute6.c
+++ b/traceroute6.c
@@ -462,7 +462,6 @@ int main(int argc, char *argv[])
 		}
 
 		memcpy(to, result->ai_addr, sizeof *to);
-		to->sin6_port = htons(port);
 		resolved_hostname = strdup(result->ai_canonname);
 		if (resolved_hostname == NULL) {
 			(void)fprintf(stderr,
@@ -472,6 +471,9 @@ int main(int argc, char *argv[])
 		hostname = resolved_hostname;
 		freeaddrinfo(result);
 	}
+
+	to->sin6_port = htons(port);
+
 	firsthop = *to;
 	if (*++argv) {
 		datalen = atoi(*argv);


### PR DESCRIPTION
Tracing to an IPv6 address was broken in 40fd68a784 when fixing tracing
to a hostname. It correctly moved the assignment to after the memcpy
into 'to', but that code path is only executed when tracing to a
hostname. The fix just moves the assignment to after the code paths for
filling out 'to' for both IPv6 addresses and hostnames.

Here's output from the current master branch:

>nate@ubuntu-testing:~/src/iputils⟫ sudo ./traceroute6 2607:f8b0:4006:80d::2004
traceroute to 2607:f8b0:4006:80d::2004 (2607:f8b0:4006:80d::2004) from 2604:a880:0:1010::1855:a001, 30 hops max, 24 byte packets
sendto: Invalid argument
 1 traceroute: wrote 2607:f8b0:4006:80d::2004 24 chars, ret=-1
 *sendto: Invalid argument
traceroute: wrote 2607:f8b0:4006:80d::2004 24 chars, ret=-1
^C

And with this patch:

>nate@ubuntu-testing:~/src/iputils⟫ sudo ./traceroute6 2607:f8b0:4006:80d::2004
traceroute to 2607:f8b0:4006:80d::2004 (2607:f8b0:4006:80d::2004) from 2604:a880:0:1010::1855:a001, 30 hops max, 24 byte packets
 1  2604:a880:0:1010:ffff:ffff:ffff:fff2 (2604:a880:0:1010:ffff:ffff:ffff:fff2)  1.192 ms  0.438 ms  0.187 ms
 2  2604:a880:ffff:1:1::21 (2604:a880:ffff:1:1::21)  0.273 ms  0.327 ms  0.282 ms
 3  2604:a880::101 (2604:a880::101)  0.313 ms  1.098 ms  1.094 ms
 4  2001:4860::1:4000:ce4b (2001:4860::1:4000:ce4b)  0.744 ms  0.812 ms  0.703 ms
 5  2001:4860:0:1::121d (2001:4860:0:1::121d)  3.514 ms  1.34 ms  1.265 ms
 6  lga15s49-in-x04.1e100.net (2607:f8b0:4006:80d::2004)  0.838 ms  0.953 ms  1.018 ms
nate@ubuntu-testing:/src/iputils⟫ sudo ./traceroute6 ipv6.google.com
traceroute to  (2607:f8b0:4006:80d::200e) from 2604:a880:0:1010::1855:a001, 30 hops max, 24 byte packets
 1  2604:a880:0:1010:ffff:ffff:ffff:fff2 (2604:a880:0:1010:ffff:ffff:ffff:fff2)  0.276 ms  0.976 ms  3.47 ms
 2  2604:a880:ffff:1:1::25 (2604:a880:ffff:1:1::25)  0.265 ms  0.335 ms  0.298 ms
 3  2604:a880::101 (2604:a880::101)  0.331 ms  0.353 ms  0.293 ms
 4  2001:4860::1:4000:ce4b (2001:4860::1:4000:ce4b)  0.866 ms  0.767 ms  0.676 ms
 5  2001:4860:0:1::121d (2001:4860:0:1::121d)  1.262 ms  1.27 ms  1.223 ms
 6  lga15s49-in-x0e.1e100.net (2607:f8b0:4006:80d::200e)  0.868 ms  0.886 ms  1.151 ms

Works for both hostname and IPv6 address tracing.
