### PR TITLE
traceroute6: Fix leaking the idn memory

### DIFF
--- a/traceroute6.c
+++ b/traceroute6.c
@@ -461,6 +461,11 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 
+		if (idn != NULL) {
+			free(idn);
+			idn = NULL;
+		}
+
 		memcpy(to, result->ai_addr, sizeof *to);
 		to->sin6_port = htons(port);
 		resolved_hostname = strdup(result->ai_canonname);


### PR DESCRIPTION
When we call idna_to_ascii_lz, it allocates memory for the output, which
is put into the idn variable. According to the man page, we're required
to free it. This change simply frees the memory if it was allocated.

Here's the valgrind output from the leak:
==30708== 16 bytes in 1 blocks are definitely lost in loss record 1 of 2
==30708==    at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==30708==    by 0x50453BF: idna_to_ascii_4z (in /usr/lib/x86_64-linux-gnu/libidn.so.11.6.15)
==30708==    by 0x5045577: idna_to_ascii_8z (in /usr/lib/x86_64-linux-gnu/libidn.so.11.6.15)
==30708==    by 0x50455D9: idna_to_ascii_lz (in /usr/lib/x86_64-linux-gnu/libidn.so.11.6.15)
==30708==    by 0x401FAB: main (traceroute6.c:454)
