### PR TITLE
ping_common.c: POLLERRR is ignored in events

### DIFF
--- a/ping_common.c
+++ b/ping_common.c
@@ -651,7 +651,7 @@ void main_loop(ping_func_set_st *fset, socket_st *sock, __u8 *packet, int packle
 			    ((options & (F_ADAPTIVE|F_FLOOD_POLL)) || interval)) {
 				struct pollfd pset;
 				pset.fd = sock->fd;
-				pset.events = POLLIN|POLLERR;
+				pset.events = POLLIN;
 				pset.revents = 0;
 				if (poll(&pset, 1, next) < 1 ||
 				    !(pset.revents&(POLLIN|POLLERR)))


### PR DESCRIPTION
See 'man poll' or fs/select.c in kernel sources, POLLERR is ignored in
events and if error happens it will be returned regardless.

Signed-off-by: Cyril Hrubis <metan@ucw.cz>