### PR TITLE
Makefile: Initialize LASTTAG variable only for target which actually uses the variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ TARGETS=ping tracepath traceroute6 clockdiff rdisc arping tftpd rarpd
 LDLIBS=$(LDLIB) $(ADDLIB)
 
 UNAME_N:=$(shell uname -n)
-LASTTAG:=$(shell git describe HEAD | sed -e 's/-.*//')
 TODAY=$(shell date +%Y-%m-%d)
 DATE=$(shell date -d $(TODAY) +%Y%m%d)
 TAG:=$(shell date -d $(TODAY) +s%Y%m%d)
@@ -238,6 +237,7 @@ distclean: clean
 RPMBUILD=rpmbuild
 RPMTMP=.rpmtmp
 snapshot:
+	$(eval LASTTAG:=$(shell git describe HEAD | sed -e 's/-.*//'))
 	@echo "[$(TAG)]" > RELNOTES.NEW
 	@echo >>RELNOTES.NEW
 	@git log --no-merges $(LASTTAG).. | git shortlog >> RELNOTES.NEW


### PR DESCRIPTION
Before this commit, we always executed

  `git describe HEAD`

when *LASTTAG* variable was not set and the Makefile was called which added a dependency on git (or you would see an error if *git* command isn't available on your system).

This commit moves the declaration of the *LASTTAG* variable into the target's recipe which is actually using this variable.

Bug: https://bugs.gentoo.org/626994