### PR TITLE
ping: Allow to ping IPv6 link-local scope address without link specification

### DIFF
--- a/ping6_common.c
+++ b/ping6_common.c
@@ -775,7 +775,11 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 			}
 			disable_capability_raw();
 		}
-		firsthop.sin6_family = AF_INET6;
+
+		if (!IN6_IS_ADDR_LINKLOCAL(&firsthop.sin6_addr) &&
+			!IN6_IS_ADDR_MC_LINKLOCAL(&firsthop.sin6_addr))
+			firsthop.sin6_family = AF_INET6;
+
 		firsthop.sin6_port = htons(1025);
 		if (connect(probe_fd, (struct sockaddr*)&firsthop, sizeof(firsthop)) == -1) {
 			perror("connect");


### PR DESCRIPTION
This reverts commit e25568f5e580d5631f533ae8474bcca40a011690.

as it breaks ping to local IPv6 interfaces:

$ ip addr |grep 'inet6'
    inet6 fe80::fc54:ff:fe2d:cc21/64 scope link

$ ./ping -6 fe80::fc54:ff:fe2d:cc21
connect: Invalid argument

Fixes #99 (regression in #57).