### PR TITLE
ping: Remove workaround for bug in IP_RECVERR on raw sockets

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -947,17 +947,6 @@ int ping4_receive_error_msg(socket_st *sock)
 
 		acknowledge(ntohs(icmph.un.echo.sequence));
 
-		if (sock->socktype == SOCK_RAW && !sock->working_recverr) {
-			struct icmp_filter filt;
-			sock->working_recverr = 1;
-			/* OK, it works. Add stronger filter. */
-			filt.data = ~((1<<ICMP_SOURCE_QUENCH)|  
-					(1<<ICMP_REDIRECT)|
-					(1<<ICMP_ECHOREPLY));
-			if (setsockopt(sock->fd, SOL_RAW, ICMP_FILTER, (char*)&filt, sizeof(filt)) == -1)
-				perror("\rWARNING: setsockopt(ICMP_FILTER)");
-		}
-
 		net_errors++;
 		nerrors++;
 		if (options & F_QUIET)

--- a/ping.h
+++ b/ping.h
@@ -286,9 +286,6 @@ extern void drop_capabilities(void);
 typedef struct socket_st {
 	int fd;
 	int socktype;
-	/* And this is workaround for bug in IP_RECVERR on raw sockets which is present
-	 * in linux-2.2.[0-19], linux-2.4.[0-7] */
-	int working_recverr;
 } socket_st;
 
 char *pr_addr(void *sa, socklen_t salen);

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -876,12 +876,7 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 		exit(2);
 	}
 
-	sock->working_recverr = 1;
 	hold = 1;
-	if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_RECVERR, &hold, sizeof hold)) {
-		fprintf(stderr, "WARNING: your kernel is veeery old. No problems.\n");
-		sock->working_recverr = 0;
-	}
 
 	/* Estimate memory eaten by single packet. It is rough estimate.
 	 * Actually, for small datalen's it depends on kernel side a lot. */
@@ -909,12 +904,10 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 
 		ICMP6_FILTER_SETBLOCKALL(&filter);
 
-		if (!sock->working_recverr) {
-			ICMP6_FILTER_SETPASS(ICMP6_DST_UNREACH, &filter);
-			ICMP6_FILTER_SETPASS(ICMP6_PACKET_TOO_BIG, &filter);
-			ICMP6_FILTER_SETPASS(ICMP6_TIME_EXCEEDED, &filter);
-			ICMP6_FILTER_SETPASS(ICMP6_PARAM_PROB, &filter);
-		}
+		ICMP6_FILTER_SETPASS(ICMP6_DST_UNREACH, &filter);
+		ICMP6_FILTER_SETPASS(ICMP6_PACKET_TOO_BIG, &filter);
+		ICMP6_FILTER_SETPASS(ICMP6_TIME_EXCEEDED, &filter);
+		ICMP6_FILTER_SETPASS(ICMP6_PARAM_PROB, &filter);
 
 		if (niquery_is_enabled())
 			ICMP6_FILTER_SETPASS(ICMPV6_NI_REPLY, &filter);
@@ -1442,8 +1435,6 @@ ping6_parse_reply(socket_st *sock, struct msghdr *msg, int cc, void *addr, struc
 			    !is_ours(sock, icmph1->icmp6_id))
 				return 1;
 			acknowledge(ntohs(icmph1->icmp6_seq));
-			if (sock->working_recverr)
-				return 0;
 			nerrors++;
 			if (options & F_FLOOD) {
 				write_stdout("\bE", 2);


### PR DESCRIPTION
IP_RECVERR for raw socket was broken until 2.4.9.

Removed code was added as extern int working_recverr in
iputils-ss010805 (searching in old tarballs).

See also somehow related bug in various distros:
https://bugs.debian.org/709052
https://bugzilla.redhat.com/73660
https://bugzilla.opensuse.org/927831