### PR TITLE
tracepath: fix heap-buffer-overflow [asan]

### DIFF
--- a/tracepath.c
+++ b/tracepath.c
@@ -470,7 +470,7 @@ int main(int argc, char **argv)
 		fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 		if (fd < 0)
 			continue;
-		memcpy(&target, ai->ai_addr, sizeof(target));
+		memcpy(&target, ai->ai_addr, sizeof(*ai->ai_addr));
 		targetlen = ai->ai_addrlen;
 		break;
 	}


### PR DESCRIPTION
This fixes the following issue.

==2522==ERROR: AddressSanitizer: heap-buffer-overflow on address
0x6060000009c0 at pc 0x55a6b4d1b2de bp 0x7ffd16c1d670 sp 0x7ffd16c1ce20
READ of size 128 at 0x6060000009c0 thread T0
    #0 0x55a6b4d1b2dd in __asan_memcpy (/home/src/iputils/tracepath+0xc52dd)
    #1 0x55a6b4d6cce3 in main /home/src/iputils/tracepath.c:473:3
    #2 0x7f039dccff69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)
    #3 0x55a6b4c717e9 in _start (/home/src/iputils/tracepath+0x1b7e9)

0x6060000009c0 is located 0 bytes to the right of 64-byte region [0x606000000980,0x6060000009c0)
allocated by thread T0 here:
    #0 0x55a6b4d31561 in malloc (/home/src/iputils/tracepath+0xdb561)
    #1 0x7f039dd8eb11 in gaih_inet.constprop.7 (/usr/lib/libc.so.6+0xdfb11)
    #2 0x7f039dd90373 in __GI_getaddrinfo (/usr/lib/libc.so.6+0xe1373)
    #3 0x55a6b4d01b80 in __interceptor_getaddrinfo.part.76 (/home/src/iputils/tracepath+0xabb80)
    #4 0x55a6b4d6c938 in main /home/src/iputils/tracepath.c:459:11
    #5 0x7f039dccff69 in __libc_start_main (/usr/lib/libc.so.6+0x20f69)

Signed-off-by: Sami Kerola <kerolasa@iki.fi>