### PR TITLE
tracepath: Support calling `tracepath` as `tracepath4` or `tracepath6`

### DIFF
--- a/tracepath.c
+++ b/tracepath.c
@@ -394,6 +394,12 @@ int main(int argc, char **argv)
 	setlocale(LC_ALL, "");
 #endif
 
+	/* Support being called using `tracepath4` or `tracepath6` symlinks */
+	if (argv[0][strlen(argv[0])-1] == '4')
+		hints.ai_family = AF_INET;
+	else if (argv[0][strlen(argv[0])-1] == '6')
+		hints.ai_family = AF_INET6;
+
 	while ((ch = getopt(argc, argv, "46nbh?l:m:p:")) != EOF) {
 		switch(ch) {
 		case '4':


### PR DESCRIPTION
While updating Gentoo's ebuild I noticed that it was just luck that *tracepath6* symlink caused IPv6 resolution because IPv6 is the default on most systems. But if you switch the defaults a symlinked *tracepath6* -> *tracepath* will not do what you expect.

Looks like it is only Gentoo installing *tracepath6* symlink. Not sure if we should get rid of the *tracepath6* symlink at all. However, this addition shouldn't hurt.