### PR TITLE
Fix build on MUSL

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -44,6 +44,13 @@
 
 #ifdef USE_IDN
 #include <locale.h>
+
+#ifndef AI_IDN
+#define AI_IDN 0x0040
+#endif
+#ifndef AI_CANONIDN
+#define AI_CANONIDN 0x0080
+#endif
 #endif
 
 #include "SNAPSHOT.h"

--- a/ping.h
+++ b/ping.h
@@ -37,6 +37,17 @@
 
 #ifdef USE_IDN
 #include <idn2.h>
+
+#ifndef AI_IDN
+#define AI_IDN 0x0040
+#endif
+#ifndef AI_CANONIDN
+#define AI_CANONIDN 0x0080
+#endif
+#ifndef NI_IDN
+#define NI_IDN 32
+#endif
+
 #define getaddrinfo_flags (AI_CANONNAME | AI_IDN | AI_CANONIDN)
 #define getnameinfo_flags NI_IDN
 #else

--- a/tracepath.c
+++ b/tracepath.c
@@ -29,6 +29,14 @@
 
 #ifdef USE_IDN
 #include <locale.h>
+
+#ifndef AI_IDN
+#define AI_IDN 0x0040
+#endif
+#ifndef NI_IDN
+#define NI_IDN 32
+#endif
+
 #define getnameinfo_flags	NI_IDN
 #else
 #define getnameinfo_flags	0

--- a/traceroute6.c
+++ b/traceroute6.c
@@ -246,6 +246,10 @@
 #ifdef USE_IDN
 #include <locale.h>
 
+#ifndef NI_IDN
+#define NI_IDN 32
+#endif
+
 #define ADDRINFO_IDN_FLAGS	AI_IDN
 #define getnameinfo_flags	NI_IDN
 #else


### PR DESCRIPTION
Add missing AI_IDN and NI_IDN declarations.

Bug: https://bugs.gentoo.org/503914