### PR TITLE
doc/ping: Update Interface section

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -163,9 +163,10 @@ If <emphasis remap='I'>interface</emphasis> is an address, it sets source addres
 to specified interface address.
 If <emphasis remap='I'>interface</emphasis> in an interface name, it sets
 source interface to specified interface.
-For IPv6, when doing ping to a link-local scope
+NOTE: For IPv6, when doing ping to a link-local scope
 address, link specification (by the '%'-notation in
-<emphasis remap='I'>destination</emphasis>, or by this option) is required.</para>
+<emphasis remap='I'>destination</emphasis>, or by this option)
+can be used but it is no longer required.</para>
   </listitem>
   </varlistentry>
   <varlistentry>


### PR DESCRIPTION
db77fb5 (Revert "correctly initialize first hop") allows to ping IPv6
link-local scope address without link specification.

It used to be possible in the past: added in f68eec0 ("ping: perform
dual-stack ping by default") and removed again in e25568f ("correctly
initialize first hop").

Signed-off-by: Petr Vorel <pvorel@suse.cz>