### PR TITLE
ping/IPv6: Enforce using specified interface

### DIFF
--- a/ping6_common.c
+++ b/ping6_common.c
@@ -763,13 +763,16 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 			    IN6_IS_ADDR_MC_LINKLOCAL(&firsthop.sin6_addr))
 				firsthop.sin6_scope_id = iface;
 			enable_capability_raw();
-			if (
+
+			int err = 0;
 #ifdef IPV6_RECVPKTINFO
-				setsockopt(probe_fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 &&
-				setsockopt(sock->fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 &&
+			err |= setsockopt(probe_fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1;
+			err |= setsockopt(sock->fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1;
 #endif
-				setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1 &&
-				setsockopt(sock->fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1) {
+			err |= setsockopt(probe_fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1;
+			err |= setsockopt(sock->fd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device)+1) == -1;
+
+			if (err) {
 				perror("setsockopt(SO_BINDTODEVICE)");
 				exit(2);
 			}


### PR DESCRIPTION
Previous version just selected another interface if the one required
with -I didn't work and warn about it:
$ ping -I eth2 2001::2
ping6: Warning: source address might be selected on device other than eth2.
PING 2001::2(2001::2) from 2001::1 eth2: 56 data bytes
64 bytes from 2001::2: icmp_seq=1 ttl=64 time=0.784 ms

$ ping -I eth2 2001::2
This enforces it even if it means to fail:
PING 2001::2(2001::2) from 2001::3 eth2: 56 data bytes
From 2001::3: icmp_seq=1 Destination unreachable: Address unreachable

NOTE: I kept checking interface and warning about it as it can be caused
by kernel (added by 63579a1 "ping: Warn if kernel has selected source
address from other interface.")

Fixes: #88

Signed-off-by: Petr Vorel <pvorel@suse.cz>