### PR TITLE
Add support for subsecond timeouts

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -459,7 +459,7 @@ main(int argc, char **argv)
 			break;
 		case 'W':
 			lingertime = atoi(optarg);
-			if (lingertime < 0 || lingertime > INT_MAX/1000000) {
+			if (lingertime <= 0 || lingertime > INT_MAX/1000000) {
 				fprintf(stderr, "ping: bad linger time.\n");
 				exit(2);
 			}


### PR DESCRIPTION
# Issue
If timeouts (-W) between zero to one (excluding) seconds were given, without responses, ping would block infinitely as it silently rounds down timeout values to the next lower integral number.
e.g. ```ping -c 10 -i 0.2 -W 0.5 8.8.8.0``` would block infinitely (8.8.8.0 typically does not respond) instead of 2.3 seconds (9*0.2 + 0.5).

# Fix
This branch parses the '-W' parameter as double; code of -i is reused and refactored into parse_optarg_msec.
```
time ping -c 10 -i 0.2 -W 0.5 8.8.8.0
PING 8.8.8.0 (8.8.8.0) 56(84) bytes of data.

--- 8.8.8.0 ping statistics ---
10 packets transmitted, 0 received, 100% packet loss, time 1871ms
0.00user 0.00system 0:02.38elapsed 0%CPU (0avgtext+0avgdata 2952maxresident)k
```

# Discussion
The branch currently still forbids -W with zero value i.e. when using ```-W 0```, ping waited infinitely for responses. I'm not sure if this was a feature. If this is unexpected, I'll revert it.