### PR TITLE
ping: Fix ping name encoded using ACE on C locale

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -208,6 +208,8 @@ main(int argc, char **argv)
 #ifdef USE_IDN
 	setlocale(LC_ALL, "");
 #endif
+	if (!strcmp(setlocale(LC_ALL, NULL), "C"))
+		hints.ai_flags &= ~ AI_CANONIDN;
 
 	/* Support being called using `ping4` or `ping6` symlinks */
 	if (argv[0][strlen(argv[0])-1] == '4')

--- a/ping.h
+++ b/ping.h
@@ -28,6 +28,7 @@
 #include <netinet/icmp6.h>
 #include <linux/filter.h>
 #include <resolv.h>
+#include <locale.h>
 
 #ifdef CAPABILITIES
 #include <sys/prctl.h>
@@ -35,7 +36,6 @@
 #endif
 
 #ifdef USE_IDN
-#include <locale.h>
 #include <idn2.h>
 #define getaddrinfo_flags (AI_CANONNAME | AI_IDN | AI_CANONIDN)
 #define getnameinfo_flags NI_IDN


### PR DESCRIPTION
Don't use AI_CANONIDN flag for getaddrinfo() on C locale as it tries to
convert ACE encoded names (i.e. containing the xn-- prefix) into current
locale which fails for C:

    $ LC_ALL=C ping -c1 www.xn--kleine-knig-yfb.de
    ping: www.xn--kleine-knig-yfb.de: Parameter string not correctly encoded

With this fix is working:

    $ LC_ALL=C ping -c1 www.xn--kleine-knig-yfb.de
    PING antares.xn--kleine-knig-yfb.de (94.130.110.236) 56(84) bytes of data.
    64 bytes from antares.kleine-koenig.org (94.130.110.236): icmp_seq=1 ttl=50 time=18.7 ms

NOTE: Obviously pinging non ACE encoded name with C locale still fail:

    $ LC_ALL=C ping -c1 www.kleine-könig.de
    ping: www.kleine-könig.de: Parameter string not correctly encoded

Fixes: #130

Signed-off-by: Petr Vorel <pvorel@suse.cz>