### PR TITLE
ping: Fix signed overflow/conversion warning

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -544,7 +544,7 @@ int ping4_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock)
 	unsigned char *packet;
 	char *target;
 	char hnamebuf[NI_MAXHOST];
-	char rspace[3 + 4 * NROUTES + 1];	/* record route space */
+	unsigned char rspace[3 + 4 * NROUTES + 1];	/* record route space */
 	__u32 *tmp_rspace;
 
 	if (argc > 1) {


### PR DESCRIPTION
clang complains:

  ping.c:813:57: warning: implicit conversion from 'int' to 'char' changes value from 137 to -119 [-Wconstant-conversion]
                  rspace[1+IPOPT_OPTVAL] = (options & F_SO_DONTROUTE) ? IPOPT_SSRR
                                       ~                              ^~~~~~~~~~
  ../../../../../../usr/include/netinet/ip.h:263:21: note: expanded from macro 'IPOPT_SSRR'
  #define IPOPT_SSRR              137             /* strict source route */
                                ^~~
  ping.c:814:6: warning: implicit conversion from 'int' to 'char' changes value from 131 to -125 [-Wconstant-conversion]
                          : IPOPT_LSRR;
                          ^~~~~~~~~~
  ../../../../../../usr/include/netinet/ip.h:260:21: note: expanded from macro 'IPOPT_LSRR'
  #define IPOPT_LSRR              131             /* loose source route */
                                  ^~~

Signed-off-by: Brian Norris <computersforpeace@gmail.com>