### PR TITLE
tracepath: Fix copying input address

### DIFF
--- a/tracepath.c
+++ b/tracepath.c
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
 		fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 		if (fd < 0)
 			continue;
-		memcpy(&target, ai->ai_addr, sizeof(*ai->ai_addr));
+		memcpy(&target, ai->ai_addr, ai->ai_addrlen);
 		targetlen = ai->ai_addrlen;
 		break;
 	}


### PR DESCRIPTION
strace ./tracepath -6 fe80::8895:e2af:e96e:fd8f
Previously was address too short:
sendto(3, "\1\0\0\0\0\0\0\0\307\36N[\0\0\0\0w_\f\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 127952, 0, {sa_family=AF_INET6, sin6_port=htons(44444), inet_pton(AF_INET6, "fe80::", &sin6_addr), sin6_flowinfo=htonl(0), sin6_scope_id=0}, 28) = -1 EMSGSIZE (Message too long)
After fix is correct:
sendto(3, "\1\0\0\0\0\0\0\0\300\36N[\0\0\0\0'B\3\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 127952, 0, {sa_family=AF_INET6, sin6_port=htons(44444), inet_pton(AF_INET6, "fe80::8895:e2af:e96e:fd8f", &sin6_addr), sin6_flowinfo=htonl(0), sin6_scope_id=0}, 28) = -1 EMSGSIZE (Message too long)

Fixes: e669c86 tracepath: fix heap-buffer-overflow [asan]