### PR TITLE
Fix Rounding Issue #141

### DIFF
--- a/ping_common.c
+++ b/ping_common.c
@@ -856,11 +856,11 @@ restamp:
 			if (triptime >= 100000)
 				printf(" time=%ld ms", (triptime+500)/1000);
 			else if (triptime >= 10000)
-				printf(" time=%ld.%01ld ms", triptime/1000,
-				       ((triptime%1000)+50)/100);
+				printf(" time=%ld.%01ld ms", (triptime+50)/1000,
+				       ((triptime+50)%1000)/100);
 			else if (triptime >= 1000)
-				printf(" time=%ld.%02ld ms", triptime/1000,
-				       ((triptime%1000)+5)/10);
+				printf(" time=%ld.%02ld ms", (triptime+5)/1000,
+				       ((triptime+5)%1000)/10);
 			else
 				printf(" time=%ld.%03ld ms", triptime/1000,
 				       triptime%1000);


### PR DESCRIPTION
Rounding of triptimes like 17950 usec were printed as 17.10 ms instead of the correct 18.0 ms.
Was: (17950 % 1000 -> 950 + 50 -> 1000 / 100 -> 10)
Should be: (17950 + 50 -> 18000 % 1000 -> 0 / 100 -> 0)