### PR TITLE
Fix mdev calculation and description

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -475,7 +475,7 @@ loss calculation, although the round trip time of these packets is used
 in calculating the minimum/average/maximum/mdev round-trip time numbers.
 </para>
 <para>
-Median deviation (mdev), essentially an average of how far each ping RTT is from the mean RTT. The higher mdev is, the more variable the RTT is (over time).
+Population standard deviation (mdev), essentially an average of how far each ping RTT is from the mean RTT. The higher mdev is, the more variable the RTT is (over time).
 
 With a high RTT variability, you will have speed issues with bulk transfers (they will take longer than is strictly speaking necessary, as the variability will eventually cause the sender to wait for ACKs) and you will have middling to poor VoIP quality.
 </para>

--- a/ping.h
+++ b/ping.h
@@ -192,8 +192,8 @@ extern jmp_buf pr_addr_jmp;
 extern int timing;			/* flag to do timing */
 extern long tmin;			/* minimum round trip time */
 extern long tmax;			/* maximum round trip time */
-extern long long tsum;			/* sum of all times, for doing average */
-extern long long tsum2;
+extern double tsum;			/* sum of all times, for doing average */
+extern double tsum2;
 extern int rtt;
 extern __u16 acked;
 extern int pipesize;

--- a/ping_common.c
+++ b/ping_common.c
@@ -80,8 +80,8 @@ long tmax;			/* maximum round trip time */
  * "sparcfix" patch is a complete non-sense, apparenly the person
  * prepared it was stoned.
  */
-long long tsum;			/* sum of all times, for doing average */
-long long tsum2;
+double tsum;			/* sum of all times, for doing average */
+double tsum2;
 int  pipesize = -1;
 
 int datalen = DEFDATALEN;
@@ -939,7 +939,7 @@ void finish(void)
 	putchar('\n');
 
 	if (nreceived && timing) {
-		long tmdev;
+		double tmdev;
 
 		tsum /= nreceived + nrepeats;
 		tsum2 /= nreceived + nrepeats;
@@ -947,7 +947,7 @@ void finish(void)
 
 		printf("rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms",
 		       (long)tmin/1000, (long)tmin%1000,
-		       (unsigned long)(tsum/1000), (long)(tsum%1000),
+		       (unsigned long)(tsum/1000), (long)tsum%1000,
 		       (long)tmax/1000, (long)tmax%1000,
 		       (long)tmdev/1000, (long)tmdev%1000
 		       );


### PR DESCRIPTION
Implicit conversion of int-type divided by int-type results in int-type, but result should be of float-type. Fixed by changing int-type variables to float-type for correct calculation of mdev parameter, which is now in line with freebsd ping implementation.

Additionally, the description of the mdev parameter was fixed: there is no such thing as a "Median deviation". The mdev parameter states the population standard deviation, commonly refered to as "mean deviation". I would also argue to change the parameter name to "stddev" for clarification and to be in line with freebsd ping. 