### PR TITLE
Fixed comment of pinger functions

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -970,7 +970,7 @@ out:
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
  * will be added on by the kernel.  The ID field is our UNIX process ID,
- * and the sequence number is an ascending integer.  The first 8 bytes
+ * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.
  */

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -1117,7 +1117,7 @@ out:
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
  * will be added on by the kernel.  The ID field is our UNIX process ID,
- * and the sequence number is an ascending integer.  The first 8 bytes
+ * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.
  */

--- a/ping_common.c
+++ b/ping_common.c
@@ -337,7 +337,7 @@ void print_timestamp(void)
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
  * will be added on by the kernel.  The ID field is our UNIX process ID,
- * and the sequence number is an ascending integer.  The first 8 bytes
+ * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.
  */


### PR DESCRIPTION
"timeval" struct is 8 bytes in x86 but it is 16 bytes in x86_64.
So I think these comments are a little bit confusing.

> The first 8 bytes	and the sequence number is an ascending integer.  The first several bytes of the data portion are used to hold a UNIX "timeval" struct in VAX of the data portion are used to hold a UNIX "timeval" struct in VAX byte-order, to compute the round-trip time.