### PR TITLE
doc/ninfod: Fix the debug mode option (-a -> -d)

### DIFF
--- a/doc/ninfod.xml
+++ b/doc/ninfod.xml
@@ -34,7 +34,7 @@ Queries can be sent by various implementations of <emphasis remap='B'>ping6</emp
   <title>OPTIONS</title>
 <variablelist remap='TP'>
   <varlistentry>
-  <term><option>-a</option></term>
+  <term><option>-d</option></term>
   <listitem>
 <para>Debug mode.  Do not go background.</para>
   </listitem>


### PR DESCRIPTION
It's a very trivial fix for a typo in the man page of `ninfod`. I noticed this recently and suppose it helps nevertheless :)