### PR TITLE
ping: check getifaddrs(3) ifa_name data before use

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -644,7 +644,8 @@ int ping4_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock)
 			if (ret)
 				error(2, errno, "gatifaddrs failed");
 			for (ifa = ifa0; ifa; ifa = ifa->ifa_next) {
-				if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET)
+				if (!ifa->ifa_name || !ifa->ifa_addr ||
+				    ifa->ifa_addr->sa_family != AF_INET)
 					continue;
 				if (!strcmp(ifa->ifa_name, device) &&
 				    !memcmp(&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr,

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -660,7 +660,8 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 				error(2, errno, "getifaddrs");
 
 			for (ifa = ifa0; ifa; ifa = ifa->ifa_next) {
-				if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET6)
+				if (!ifa->ifa_name || !ifa->ifa_addr ||
+				    ifa->ifa_addr->sa_family != AF_INET6)
 					continue;
 				if (!strcmp(ifa->ifa_name, device) &&
 				    IN6_ARE_ADDR_EQUAL(&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr,


### PR DESCRIPTION
The getifaddrs(3) can return invalid data when system call is interrupted.
Issue was fixed in glibc 2.28 (relesed 2018-08-01). It is fair to assume
there are systems with older libc so make the ping more robust and check
ifa->ifa_name is not NULL before using it.

Reference: https://sourceware.org/bugzilla/show_bug.cgi?id=21812
Addresses: https://github.com/iputils/iputils/issues/112
Signed-off-by: Sami Kerola <kerolasa@iki.fi>