### PR TITLE
ninfod: fix couple warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('iputils', 'c',
 	default_options : [
 		'c_std=c99',
-		'warning_level=2',
+		'warning_level=3',
 	],
 	version : 's20180629') # keep in sync with: git describe | awk -F- '{print $1}'
 

--- a/ninfod/ni_ifaddrs.c
+++ b/ninfod/ni_ifaddrs.c
@@ -157,7 +157,8 @@ static int nl_getmsg(int sd, uint32_t seq, struct nlmsghdr **nlhp, int *done)
 	struct nlmsghdr *nh;
 	size_t bufsize = 65536, lastbufsize = 0;
 	void *buff = NULL;
-	int result = 0, read_size;
+	int result = 0;
+	size_t read_size;
 	int msg_flags;
 	pid_t pid = getpid();
 	for (;;) {
@@ -342,14 +343,15 @@ int ni_ifaddrs(struct ni_ifaddrs **ifap, sa_family_t family)
 	for (build = 0; build <= 1; build++) {
 		struct ni_ifaddrs *ifl = NULL, *ifa = NULL;
 		struct nlmsghdr *nlh, *nlh0;
-		void *data = NULL, *xdata = NULL;
+		uint8_t *data = NULL, *xdata = NULL;
 #ifndef IFA_LOCAL
 		struct rtmaddr_ifamap ifamap;
 #endif
 
 		if (build) {
-			ifa = data = calloc(1, NLMSG_ALIGN(sizeof(struct ni_ifaddrs[icnt]))
-					    + dlen + xlen);
+			data = calloc(1, NLMSG_ALIGN(sizeof(struct ni_ifaddrs[icnt]))
+				      + dlen + xlen);
+			ifa = (struct ni_ifaddrs *) data;
 			if (ifap != NULL)
 				*ifap = ifa;
 			else {
@@ -366,7 +368,7 @@ int ni_ifaddrs(struct ni_ifaddrs **ifap, sa_family_t family)
 		}
 
 		for (nlm = nlmsg_list; nlm; nlm = nlm->nlm_next) {
-			int nlmlen = nlm->size;
+			size_t nlmlen = nlm->size;
 			if (!(nlh0 = nlm->nlh))
 				continue;
 			for (nlh = nlh0; NLMSG_OK(nlh, nlmlen); nlh = NLMSG_NEXT(nlh, nlmlen)) {
@@ -461,7 +463,8 @@ int ni_ifaddrs(struct ni_ifaddrs **ifap, sa_family_t family)
 								xlen += NLMSG_ALIGN(rtapayload);
 							else {
 								memcpy(xdata, rtadata, rtapayload);
-								ifa->ifa_cacheinfo = xdata;
+								ifa->ifa_cacheinfo =
+									(struct ifa_cacheinfo *) xdata;
 								xdata += NLMSG_ALIGN(rtapayload);
 							}
 							break;


### PR DESCRIPTION
arithmetic on a pointer to void is a GNU extension [-Wpointer-arith]

comparison of integers of different signs: '__u32' (aka 'unsigned int') and
'int' [-Wsign-compare]

After these it's ok to use warning level 3 in meson build.

p.s. I could not push to origin/master. No idea what happen there..

Signed-off-by: Sami Kerola <kerolasa@iki.fi>