### PR TITLE
Libcommon

### DIFF
--- a/iputils_common.c
+++ b/iputils_common.c
@@ -1,0 +1,27 @@
+#ifndef HAVE_ERROR_H
+# include <errno.h>
+# include <stdarg.h>
+# include <stdio.h>
+
+void error(int status, int errnum, const char *format, ...)
+{
+	va_list ap;
+
+	fprintf(stderr, "%s: ", program_invocation_short_name);
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	if (errnum)
+		fprintf(stderr, ": %s\n", strerror(errnum));
+	else
+		fprintf(stderr, "\n");
+	if (status)
+		exit(status);
+}
+#else
+/*
+ * FIXME: this can be removed when this file has some (any) content that is
+ * not within preprocessor condition(s).
+ */
+typedef int make_iso_compilers_happy;
+#endif

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -16,4 +16,10 @@
 # define _(Text) Text
 #endif
 
+#ifdef HAVE_ERROR_H
+# include <error.h>
+#else
+extern void error(int status, int errnum, const char *format, ...);
+#endif
+
 #endif /* IPUTILS_COMMON_H */

--- a/meson.build
+++ b/meson.build
@@ -249,6 +249,7 @@ endif
 if build_rinfod == true
 	executable('rdisc', ['rdisc.c', git_version_h],
 		install_dir: 'sbin',
+		link_with : [libcommon],
 		install: true)
 	if systemd.found()
 		subs = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -196,9 +196,16 @@ else
 endif
 
 ############################################################
+common_sources = files('iputils_common.h', 'iputils_common.c')
+libcommon = static_library(
+	'common',
+	[common_sources, git_version_h],
+	install : false)
+
 if build_ping == true
 	executable('ping', ['ping.c', 'ping_common.c', 'ping6_common.c', git_version_h],
 		dependencies : [m_dep, cap_dep, idn_dep, crypto_dep, resolv_dep],
+		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',
 		join_paths(get_option('prefix'), get_option('bindir')),

--- a/meson.build
+++ b/meson.build
@@ -218,6 +218,7 @@ endif
 if build_tracepath == true
 	executable('tracepath', ['tracepath.c', git_version_h],
 		dependencies : idn_dep,
+		link_with : [libcommon],
 		install: true)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -283,6 +283,7 @@ endif
 if build_rarpd == true
 	executable('rarpd', ['rarpd.c', git_version_h],
 		install_dir: 'sbin',
+		link_with : [libcommon],
 		install: true)
 	if systemd.found()
 		subs = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -264,6 +264,7 @@ endif
 if build_arping == true
 	executable('arping', ['arping.c', git_version_h],
 		dependencies : [rt_dep, cap_dep, idn_dep],
+		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',
 		join_paths(get_option('prefix'), get_option('bindir')),

--- a/meson.build
+++ b/meson.build
@@ -236,6 +236,7 @@ endif
 if build_clockdiff == true
 	executable('clockdiff', ['clockdiff.c', git_version_h],
 		dependencies : [cap_dep],
+		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',
 		join_paths(get_option('prefix'), get_option('bindir')),

--- a/meson.build
+++ b/meson.build
@@ -225,6 +225,7 @@ endif
 if build_traceroute6 == true
 	executable('traceroute6', ['traceroute6.c', git_version_h],
 		dependencies : [cap_dep, idn_dep],
+		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',
 		join_paths(get_option('prefix'), get_option('bindir')),

--- a/ping.h
+++ b/ping.h
@@ -29,12 +29,6 @@
 #include <linux/filter.h>
 #include <resolv.h>
 
-#ifdef HAVE_ERROR_H
-#include <error.h>
-#else
-#include <stdarg.h>
-#endif
-
 #ifdef HAVE_LIBCAP
 #include <sys/prctl.h>
 #include <sys/capability.h>
@@ -155,24 +149,6 @@ static inline bitmap_t rcvd_test(uint16_t seq)
 	unsigned bit = seq % MAX_DUP_CHK;
 	return A(bit) & B(bit);
 }
-
-#ifndef HAVE_ERROR_H
-static void error(int status, int errnum, const char *format, ...)
-{
-	va_list ap;
-
-	fprintf(stderr, "ping: ");
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	if (errnum)
-		fprintf(stderr, ": %s\n", strerror(errnum));
-	else
-		fprintf(stderr, "\n");
-	if (status)
-		exit(status);
-}
-#endif
 
 extern int datalen;
 extern char *hostname;

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -629,8 +629,7 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 			if (
 				setsockopt(probe_fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1 ||
 				setsockopt(sock->fd, IPPROTO_IPV6, IPV6_PKTINFO, &ipi, sizeof ipi) == -1) {
-				perror("setsockopt(IPV6_PKTINFO)");
-				exit(2);
+				error(2, errno, "setsockopt(IPV6_PKTINFO)");
 			}
 #endif
 			if (

--- a/ping_common.c
+++ b/ping_common.c
@@ -476,7 +476,7 @@ hard_local_error:
 		if (options & F_FLOOD)
 			write_stdout("E", 1);
 		else
-			perror("ping: sendmsg");
+			error(0, errno, "sendmsg");
 	}
 	tokens = 0;
 	return SCHINT(interval);

--- a/rarpd.c
+++ b/rarpd.c
@@ -30,6 +30,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
+#include "iputils_common.h"
 
 int do_reload = 1;
 
@@ -627,7 +628,7 @@ int main(int argc, char **argv)
 		memset(&ifr, 0, sizeof(ifr));
 		strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 		if (ioctl(pset[0].fd, SIOCGIFINDEX, &ifr)) {
-			perror("ioctl(SIOCGIFINDEX)");
+			error(0, errno, "ioctl(SIOCGIFINDEX)");
 			usage();
 		}
 		ifidx = ifr.ifr_ifindex;
@@ -669,10 +670,8 @@ int main(int argc, char **argv)
 		pset[0] = pset[1];
 		psize--;
 	}
-	if (psize == 0) {
-		fprintf(stderr, "failed to bind any socket. Aborting.\n");
-		exit(1);
-	}
+	if (psize == 0)
+		error(1, errno, "failed to bind any socket");
 
 	if (!debug) {
 		int fd;
@@ -680,15 +679,11 @@ int main(int argc, char **argv)
 
 		if (pid > 0)
 			exit(0);
-		else if (pid == -1) {
-			perror("rarpd: fork");
-			exit(1);
-		}
+		else if (pid == -1)
+			error(1, errno, "fork");
 
-		if (chdir("/") < 0) {
-			perror("rarpd: chdir");
-			exit(1);
-		}
+		if (chdir("/") < 0)
+			error(1, errno, "chdir");
 
 		fd = open("/dev/null", O_RDWR);
 		if (fd >= 0) {

--- a/rdisc.c
+++ b/rdisc.c
@@ -63,6 +63,8 @@
 #include <string.h>
 #include <syslog.h>
 
+#include "iputils_common.h"
+
 struct interface
 {
 	struct in_addr 	address;	/* Used to identify the interface */
@@ -261,15 +263,10 @@ void do_fork(void)
 	if (trace)
 		return;
 	if ((open_max = sysconf(_SC_OPEN_MAX)) == -1) {
-		if (errno == 0) {
-			(void) fprintf(stderr, "OPEN_MAX is not supported\n");
-		} 
-		else {
-			(void) fprintf(stderr, "sysconf() error\n");
-		}
-		exit(1);
+		if (errno == 0)
+			error(1, 0, "sysconf(_SC_OPEN_MAX) is not supported");
+		error(1, errno, "sysconf(_SC_OPEN_MAX)");
 	}
-
 
 	if ((pid=fork()) != 0)
 		exit(0);
@@ -349,11 +346,9 @@ int main(int argc, char **argv)
 				argc--, av++;
 				if (argc != 0) {
 					val = strtol(av[0], (char **)NULL, 0);
-					if (val < 4 || val > 1800) {
-						(void) fprintf(stderr,
-							       "Bad Max Advertizement Interval\n");
-						exit(1);
-					}
+					if (val < 4 || val > 1800)
+						error(1, 0, "Bad Max Advertizement Interval: %d",
+							     val);
 					max_adv_int = val;
 					min_adv_int =( max_adv_int * 3 / 4);
 					lifetime = (3*max_adv_int);
@@ -411,7 +406,7 @@ next:
 		argc--;
 	}
 	if (argc != 0) {
-		(void) fprintf(stderr, "Extra parameters\n");
+		error(0, 0, "Extra parameters");
 		prusage();
 		/* NOTREACHED */
 	}


### PR DESCRIPTION
Add internal to project library, libcommon, that contains error() portability function shared by most of the programs. The libcommon can later be used to share other functions, such as gnulib style close_stdout() to notify use at exit if write failed.

http://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=blob;f=lib/closeout.c;h=0672732b634e8153d076cffffc72540015e79c92;hb=HEAD#l117