### PR TITLE
clockdiff: remove unused localhost info.

### DIFF
--- a/clockdiff.c
+++ b/clockdiff.c
@@ -473,7 +473,6 @@ int main(int argc, char **argv)
 	};
 	struct addrinfo *result;
 	int status;
-	char hostname[MAX_HOSTNAMELEN];
 
 	atexit(close_stdout);
 	if (argc == 2 && !strcmp(argv[1], "-V")) {
@@ -508,13 +507,6 @@ int main(int argc, char **argv)
 		ctl.interactive = 1;
 
 	ctl.id = getpid();
-
-	gethostname(hostname, sizeof(hostname));
-	status = getaddrinfo(hostname, NULL, &hints, &result);
-	if (status)
-		error(2, 0, "%s: %s", hostname, gai_strerror(status));
-	ctl.myname = strdup(result->ai_canonname);
-	freeaddrinfo(result);
 
 	status = getaddrinfo(argv[1], NULL, &hints, &result);
 	if (status)

--- a/clockdiff.c
+++ b/clockdiff.c
@@ -78,8 +78,6 @@
 
 #include "iputils_common.h"
 
-#define MAX_HOSTNAMELEN	NI_MAXHOST
-
 enum {
 	RANGE = 1,		/* best expected round-trip time, ms */
 	MSGS = 50,
@@ -114,7 +112,6 @@ struct run_state {
 	long rtt;
 	long min_rtt;
 	long rtt_sigma;
-	char *myname;
 	char *hisname;
 };
 


### PR DESCRIPTION
I had some issues with getaddrinfo on one of the aws machines. Couldn't figure out what was wrong with this call, but since ctl.myname is never used, I figured it's easier just to delete it.

I offer this patch, because others may experience the same issue.