### PR TITLE
doc: Use namespace correctly

### DIFF
--- a/doc/arping.xml
+++ b/doc/arping.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.arping">
 
   <refentryinfo>

--- a/doc/clockdiff.xml
+++ b/doc/clockdiff.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.clockdiff">
 
   <refentryinfo>

--- a/doc/custom-html.xsl
+++ b/doc/custom-html.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/html/docbook.xsl"/>
 <!--
   - The docbook stylesheet injects empty anchor tags into generated HTML, identified by an auto-generated ID.
   - Ask the docbook stylesheet to generate reproducible output when generating (these) ID values.

--- a/doc/custom-man.xsl
+++ b/doc/custom-man.xsl
@@ -5,7 +5,7 @@
                 extension-element-prefixes="exsl"
                 version="1.0">
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl"/>
 
 <xsl:template name="top.comment" />
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -49,7 +49,7 @@ xsltproc_args = [
 
 if xsltproc.found()
 	testrun = run_command([xsltproc, '--nonet',
-		'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'])
+		'http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl'])
 	xsltproc_works = testrun.returncode() == 0
 else
 	warning('No docbook stylesheet found for generating man pages')

--- a/doc/ninfod.xml
+++ b/doc/ninfod.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.ninfod">
 
   <refentryinfo>

--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.ping">
 
   <refentryinfo>

--- a/doc/rarpd.xml
+++ b/doc/rarpd.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.rarpd">
 
   <refentryinfo>

--- a/doc/rdisc.xml
+++ b/doc/rdisc.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.rdisc">
 
   <refentryinfo>

--- a/doc/tftpd.xml
+++ b/doc/tftpd.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.tftpd">
 
   <refentryinfo>

--- a/doc/tracepath.xml
+++ b/doc/tracepath.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.tracepath">
 
   <refentryinfo>

--- a/doc/traceroute6.xml
+++ b/doc/traceroute6.xml
@@ -1,4 +1,4 @@
-<refentry xmlns:db="http://docbook.org/ns/docbook" version="5.0"
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0"
 xml:id="man.traceroute6">
 
   <refentryinfo>


### PR DESCRIPTION
The files declared xmlns:db but did not use the db namespace at all. They did not define the default namespace at all, which coincidentally worked with Docbook 4 stylesheets, making them think the files 
were written in Docbook 4.

I fixed the namespaces of the documents and switched to the correct Docbook 5 stylesheets.

cc @dtzWill