### PR TITLE
arping: Fix packets count

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -689,10 +689,11 @@ static int event_loop(struct run_state *ctl)
 	struct signalfd_siginfo sigval;
 
 	int tfd;
-	struct timespec now = { 0 };
 	struct itimerspec timerfd_vals = {
 		.it_interval.tv_sec = ctl->interval,
-		.it_interval.tv_nsec = 0
+		.it_interval.tv_nsec = 0,
+		.it_value.tv_sec = ctl->interval,
+		.it_value.tv_nsec = 0
 	};
 	uint64_t exp, total_expires = 1;
 
@@ -723,13 +724,7 @@ static int event_loop(struct run_state *ctl)
 		error(0, errno, "timerfd_create failed");
 		return 1;
 	}
-	if (clock_gettime(CLOCK_MONOTONIC_RAW, &now) == -1) {
-		error(0, errno, "clock_gettime failed");
-		return 1;
-	}
-	timerfd_vals.it_value.tv_sec = now.tv_sec + ctl->interval;
-	timerfd_vals.it_value.tv_nsec = now.tv_nsec;
-	if (timerfd_settime(tfd, TFD_TIMER_ABSTIME, &timerfd_vals, NULL)) {
+	if (timerfd_settime(tfd, 0, &timerfd_vals, NULL)) {
 		error(0, errno, "timerfd_settime failed");
 		return 1;
 	}

--- a/ping.c
+++ b/ping.c
@@ -543,19 +543,20 @@ int ping4_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock)
 				options |= F_NUMERIC;
 		} else {
 			struct addrinfo *result = NULL;
+			struct addrinfo *tmp_ai = ai;
 			int ret_val;
 
-			if (argc > 1 || !ai) {
+			if (argc > 1 || !tmp_ai) {
 				ret_val = getaddrinfo(target, NULL, &hints, &result);
 				if (ret_val)
 					error(2, 0, "%s: %s", target, gai_strerror(ret_val));
-				ai = result;
+				tmp_ai = result;
 			}
 
-			memcpy(&whereto, ai->ai_addr, sizeof whereto);
+			memcpy(&whereto, tmp_ai->ai_addr, sizeof whereto);
 			memset(hnamebuf, 0, sizeof hnamebuf);
-			if (ai->ai_canonname)
-				strncpy(hnamebuf, ai->ai_canonname, sizeof hnamebuf - 1);
+			if (tmp_ai->ai_canonname)
+				strncpy(hnamebuf, tmp_ai->ai_canonname, sizeof hnamebuf - 1);
 			hostname = hnamebuf;
 
 			if (result)

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -57,6 +57,7 @@
  *	if -N option is used, this program has to run SUID to ROOT or
  *	with net_cap_raw enabled.
  */
+#include <stddef.h>
 #include "iputils_common.h"
 #include "iputils_ni.h"
 #include "ping.h"


### PR DESCRIPTION
On my system values of CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW differed by about 18 seconds. Therefore arping -c3 exited immediately after start.
Also I got implicit declaration of function 'offsetof' warning when compiling with USE_CRYPTO=kernel.