### PR TITLE
Use the value of sbindir to install rinfod, rarpd & ninfod

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -282,7 +282,7 @@ endif
 
 if build_rinfod == true
 	executable('rdisc', ['rdisc.c', git_version_h],
-		install_dir: 'sbin',
+		install_dir: get_option('sbindir'),
 		link_with : [libcommon],
 		install: true)
 	if systemd.found()
@@ -318,7 +318,7 @@ endif
 
 if build_rarpd == true
 	executable('rarpd', ['rarpd.c', git_version_h],
-		install_dir: 'sbin',
+		install_dir: get_option('sbindir'),
 		link_with : [libcommon],
 		install: true)
 	if systemd.found()

--- a/ninfod/meson.build
+++ b/ninfod/meson.build
@@ -14,7 +14,7 @@ executable('ninfod', [ninfod_sources, git_version_h],
 	link_with : [libcommon],
 	include_directories : inc,
 	install: true,
-	install_dir: 'sbin')
+	install_dir: get_option('sbindir'))
 conf_data = configuration_data()
 conf_data.set('prefix', get_option('prefix'))
 


### PR DESCRIPTION
...instead of hard-coding 'sbin'.