### PR TITLE
Various fixes and improvements for the build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
       - "libidn2-0-dev"
       - "nettle-dev"
       - "xsltproc"
-      - "docbook-xsl"
       - "docbook-xsl-ns"
 matrix:
   include:

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -38,7 +38,7 @@ if build_ninfod == true
 	manpages += ['ninfod']
 endif
 
-xsltproc = find_program('xsltproc', required : true)
+xsltproc = find_program('xsltproc', required : build_mans or build_html_mans)
 xsltproc_args = [
 	'--nonet',
 	'--stringparam', 'man.output.quietly', '1',
@@ -48,19 +48,26 @@ xsltproc_args = [
 ]
 
 if xsltproc.found()
-	xsl = 'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl'
-	testrun = run_command([xsltproc, '--nonet', xsl])
-	xsltproc_works = testrun.returncode() == 0
-	if xsltproc_works == false
-		warning('xsltproc: cannot process ' + xsl)
+	doc_targets = []
+	if build_mans
+		doc_targets += ['manpages']
 	endif
-else
-	warning('No docbook stylesheet found for generating man pages')
-	xsltproc_works = false
+	if build_html_mans
+		doc_targets += ['html']
+	endif
+	xsltproc_works = true
+	foreach doc_target : doc_targets
+		xsl = 'http://docbook.sourceforge.net/release/xsl-ns/current/' + doc_target + '/docbook.xsl'
+		testrun = run_command([xsltproc, '--nonet', xsl])
+		if testrun.returncode() != 0
+			xsltproc_works = false
+			warning('xsltproc: cannot process ' + xsl)
+		endif
+	endforeach
 endif
 
 if xsltproc_works == false
-	error('Man pages cannot be built: xsltproc does not work correctly')
+	error('Docs cannot be built: xsltproc does not work correctly')
 endif
 
 if build_mans

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -61,7 +61,7 @@ if xsltproc.found()
 		testrun = run_command([xsltproc, '--nonet', xsl])
 		if testrun.returncode() != 0
 			xsltproc_works = false
-			warning('xsltproc: cannot process ' + xsl)
+			message('WARNING: xsltproc: cannot process ' + xsl)
 		endif
 	endforeach
 endif

--- a/meson.build
+++ b/meson.build
@@ -221,10 +221,13 @@ config_h = configure_file(
 setcap = find_program('setcap', '/usr/sbin/setcap', '/sbin/setcap', required : false)
 if get_option('NO_SETCAP_OR_SUID')
 	perm_type = 'none'
+	setcap_path = '/dev/null'
 elif cap_dep.found() and setcap.found()
 	perm_type = 'caps'
+	setcap_path = setcap.path()
 else
 	perm_type = 'setuid'
+	setcap_path = '/dev/null'
 endif
 
 ############################################################
@@ -243,7 +246,7 @@ if build_ping == true
 		join_paths(get_option('prefix'), get_option('bindir')),
 		'ping',
 		perm_type,
-		setcap.path()
+		setcap_path
 	)
 endif
 
@@ -263,7 +266,7 @@ if build_traceroute6 == true
 		join_paths(get_option('prefix'), get_option('bindir')),
 		'traceroute6',
 		perm_type,
-		setcap.path()
+		setcap_path
 	)
 endif
 
@@ -276,7 +279,7 @@ if build_clockdiff == true
 		join_paths(get_option('prefix'), get_option('bindir')),
 		'clockdiff',
 		perm_type,
-		setcap.path()
+		setcap_path
 	)
 endif
 
@@ -306,7 +309,7 @@ if build_arping == true
 		join_paths(get_option('prefix'), get_option('bindir')),
 		'arping',
 		perm_type,
-		setcap.path()
+		setcap_path
 	)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('iputils', 'c',
 		'c_std=c99',
 		'warning_level=3',
 	],
+	meson_version : '>=0.39',
 	version : 's20190515') # keep in sync with: git describe | awk -F- '{print $1}'
 
 cc = meson.get_compiler('c')
@@ -211,7 +212,8 @@ endforeach
 
 git_version_h = vcs_tag(
 	input : 'git-version.h.meson',
-	output : 'git-version.h'
+	output : 'git-version.h',
+	fallback : meson.project_version()
 )
 
 config_h = configure_file(


### PR DESCRIPTION
The first commit improves the error messages when building with older versions of Meson (+ updates the project version), the second commit makes `setcap` really optional, and the third commit removes the old dependency on `docbook-xsl`.

So none of these changes are critical fixes, but they should improve the build experience in certain cases.