### PR TITLE
ninfod/ninfod_name.c: fix build with nettle

### DIFF
--- a/ninfod/ninfod_name.c
+++ b/ninfod/ninfod_name.c
@@ -95,7 +95,7 @@
 
 #include <arpa/inet.h>
 
-#if defined(HAVE_GCRYPT_H) || defined(USE_KERNEL_CRYPTO_API)
+#if defined(HAVE_GCRYPT_H) || defined(USE_KERNEL_CRYPTO_API) || defined(USE_NETTLE)
 # include "iputils_md5dig.h"
 #elif defined(HAVE_GNUTLS_OPENSSL_H)
 # include <gnutls/openssl.h>


### PR DESCRIPTION
Build of ninfod with nettle fails on:
/home/test/autobuild/run/instance-1/output/host/bin/mips64el-linux-gcc  -o ninfod/ninfod 'ninfod/0cb6efe@@ninfod@exe/ni_ifaddrs.c.o' 'ninfod/0cb6efe@@ninfod@exe/ninfod.c.o' 'ninfod/0cb6efe@@ninfod@exe/ninfod_addrs.c.o' 'ninfod/0cb6efe@@ninfod@exe/ninfod_core.c.o' 'ninfod/0cb6efe@@ninfod@exe/ninfod_name.c.o' -Wl,--no-undefined -Wl,--as-needed -Wl,-O1 -Wl,--start-group libcommon.a -lcap /home/test/autobuild/run/instance-1/output/host/usr/bin/../mips64el-buildroot-linux-uclibc/sysroot/usr/lib/libnettle.so -Wl,--end-group -pthread '-Wl,-rpath,$ORIGIN/..:/home/test/autobuild/run/instance-1/output/host/usr/bin/../mips64el-buildroot-linux-uclibc/sysroot/usr/lib' -Wl,-rpath-link,/home/test/autobuild/run/instance-1/output/build/iputils-s20190515/build/:/home/test/autobuild/run/instance-1/output/host/usr/bin/../mips64el-buildroot-linux-uclibc/sysroot/usr/lib
ninfod/0cb6efe@@ninfod@exe/ninfod_name.c.o: In function `init_nodeinfo_nodename':
ninfod_name.c:(.text+0x378): undefined reference to `MD5_Init'

This error is raised because MD5_Init is not defined by nettle.
To fix this error, include iputils_md5dig.h if USE_NETTLE is defined.

Fixes:
 - http://autobuild.buildroot.org/results/e86555090e27b631ba35214ef100aa9331844684

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>