### PR TITLE
meson.build: fix static build with gcrypt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,9 @@ elif crypto == 'none'
 		description : 'If set RFC6744 random does not use any CRYPTO lib.')
 endif
 
+# gpg-error is a dependency of gcrypt
+gpg_error_dep = dependency('gpg-error', required : false)
+
 systemd = dependency('systemd', required : false)
 systemdunitdir = get_option('systemdunitdir')
 if systemdunitdir == '' and systemd.found()
@@ -241,7 +244,7 @@ libcommon = static_library(
 
 if build_ping == true
 	executable('ping', ['ping.c', 'ping_common.c', 'ping6_common.c', git_version_h],
-		dependencies : [m_dep, cap_dep, idn_dep, crypto_dep, resolv_dep],
+		dependencies : [m_dep, cap_dep, idn_dep, crypto_dep, gpg_error_dep, resolv_dep],
 		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',

--- a/ninfod/meson.build
+++ b/ninfod/meson.build
@@ -10,7 +10,7 @@ ninfod_sources = files('''
 	ninfod_name.c
 '''.split())
 executable('ninfod', [ninfod_sources, git_version_h],
-	dependencies : [cap_dep, crypto_dep, rt_dep, threads],
+	dependencies : [cap_dep, crypto_dep, gpg_error_dep, rt_dep, threads],
 	link_with : [libcommon],
 	include_directories : inc,
 	install: true,


### PR DESCRIPTION
gcrypt depends on gpg-error so save the result of
cc.find_library('gpg-error') in gpg_error_dep and use it when needed to
fix static build

Fixes:
 - http://autobuild.buildroot.net/results/fb698e3e903869978bd5e69d791ec362317b7981

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>