### PR TITLE
traceroute6: fix build with NLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -266,7 +266,7 @@ endif
 
 if build_traceroute6 == true
 	executable('traceroute6', ['traceroute6.c', git_version_h],
-		dependencies : [cap_dep, idn_dep],
+		dependencies : [cap_dep, intl_dep, idn_dep],
 		link_with : [libcommon],
 		install: true)
 	meson.add_install_script('build-aux/setcap-setuid.sh',


### PR DESCRIPTION
commit 418d8be ("build-sys: fix build with NLS") fixed problems for
default packages using libintl. Fix also traceroute6 (build it must be
enabled with -DBUILD_TRACEROUTE6=true).

Signed-off-by: Petr Vorel <pvorel@suse.cz>