### PR TITLE
ping: Remove redundant space in output

### DIFF
--- a/ping.c
+++ b/ping.c
@@ -804,7 +804,7 @@ int ping4_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock)
 	if (!(packet = (unsigned char *)malloc((unsigned int)packlen)))
 		error(2, errno, _("memory allocation failed"));
 
-	printf(_("PING %s (%s) "), hostname, inet_ntoa(whereto.sin_addr));
+	printf("PING %s (%s) ", hostname, inet_ntoa(whereto.sin_addr));
 	if (device || (options & F_STRICTSOURCE))
 		printf(_("from %s %s: "), inet_ntoa(source.sin_addr), device ? device : "");
 	printf(_("%d(%d) bytes of data.\n"), datalen, datalen + 8 + optlen + 20);

--- a/ping.h
+++ b/ping.h
@@ -319,6 +319,8 @@ void fill(char *patp, unsigned char *packet, unsigned packet_size);
 extern int mark;
 extern unsigned char outpack[MAXPACKET];
 
+void print_header(int family, char *hostname, char *source, char *whereto, uint32_t flowlabel);
+
 /* IPv6 */
 
 int ping6_run(int argc, char **argv, struct addrinfo *ai, socket_st *sock);

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -828,7 +828,7 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 #endif
 	}
 
-	printf(_("PING %s(%s) "), hostname, pr_addr(&whereto, sizeof whereto));
+	printf("PING %s(%s) ", hostname, pr_addr(&whereto, sizeof whereto));
 	if (flowlabel)
 		printf(_(", flow 0x%05x, "), (unsigned)ntohl(flowlabel));
 	if (device || (options & F_STRICTSOURCE)) {

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -828,16 +828,7 @@ int ping6_run(int argc, char **argv, struct addrinfo *ai, struct socket_st *sock
 #endif
 	}
 
-	printf("PING %s(%s) ", hostname, pr_addr(&whereto, sizeof whereto));
-	if (flowlabel)
-		printf(_(", flow 0x%05x, "), (unsigned)ntohl(flowlabel));
-	if (device || (options & F_STRICTSOURCE)) {
-		int saved_options = options;
-
-		options |= F_NUMERIC;
-		printf(_("from %s %s: "), pr_addr(&source6, sizeof source6), device ? device : "");
-		options = saved_options;
-	}
+	print_header(AF_INET6, hostname, pr_addr(&source6, sizeof source6), pr_addr(&whereto, sizeof whereto), flowlabel);
 	printf(_("%d data bytes\n"), datalen);
 
 	setup(sock);

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -413,7 +413,7 @@ msgstr ""
 
 #: ping.c:812 ping6_common.c:836
 #, c-format
-msgid "from %s %s: "
+msgid "from"
 msgstr ""
 
 #: ping.c:813
@@ -1036,9 +1036,9 @@ msgstr ""
 msgid "flowinfo is not supported"
 msgstr ""
 
-#: ping6_common.c:831
+#: ping.c:1626
 #, c-format
-msgid ", flow 0x%05x, "
+msgid "flow"
 msgstr ""
 
 #: ping6_common.c:839

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -411,11 +411,6 @@ msgstr ""
 msgid "memory allocation failed"
 msgstr ""
 
-#: ping.c:810
-#, c-format
-msgid "PING %s (%s) "
-msgstr ""
-
 #: ping.c:812 ping6_common.c:836
 #, c-format
 msgid "from %s %s: "
@@ -1039,11 +1034,6 @@ msgstr ""
 
 #: ping6_common.c:825
 msgid "flowinfo is not supported"
-msgstr ""
-
-#: ping6_common.c:829
-#, c-format
-msgid "PING %s(%s) "
 msgstr ""
 
 #: ping6_common.c:831

--- a/po/ja.po
+++ b/po/ja.po
@@ -464,8 +464,8 @@ msgstr "メモリ確保に失敗しました。"
 
 #: ping.c:812 ping6_common.c:836
 #, c-format
-msgid "from %s %s: "
-msgstr "送信元 %s %s: "
+msgid "from"
+msgstr "送信元"
 
 #: ping.c:813
 #, c-format
@@ -1122,10 +1122,10 @@ msgstr "フロー情報を送信できません。"
 msgid "flowinfo is not supported"
 msgstr "フロー情報はサポートされていません。"
 
-#: ping6_common.c:831
+#: ping.c:1626
 #, c-format
-msgid ", flow 0x%05x, "
-msgstr ", フロー 0x%05x, "
+msgid "flow"
+msgstr "フロー"
 
 #: ping6_common.c:839
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -462,11 +462,6 @@ msgstr "パケットサイズ %d が大きすぎます。最大値は %d です�
 msgid "memory allocation failed"
 msgstr "メモリ確保に失敗しました。"
 
-#: ping.c:810
-#, c-format
-msgid "PING %s (%s) "
-msgstr ""
-
 #: ping.c:812 ping6_common.c:836
 #, c-format
 msgid "from %s %s: "
@@ -1126,11 +1121,6 @@ msgstr "フロー情報を送信できません。"
 #
 msgid "flowinfo is not supported"
 msgstr "フロー情報はサポートされていません。"
-
-#: ping6_common.c:829
-#, c-format
-msgid "PING %s(%s) "
-msgstr ""
 
 #: ping6_common.c:831
 #, c-format


### PR DESCRIPTION
When run ping -I IP_ADDR (i.e. not -I DEVICE) ping prints
redundant space:

$ ping -c1 -I 127.0.0.1 192.168.0.109
PING 192.168.0.109 (192.168.0.109) from 127.0.0.1 : 56(84) bytes of data.

Check for device to avoid it.

+ create print_header() to reduce duplicity.
+ translate only "flow" and "from" (not with surrounding formatting data)