### PR TITLE
security: Disable setcap and setuid for arping

### DIFF
--- a/build-aux/setcap-setuid.sh
+++ b/build-aux/setcap-setuid.sh
@@ -14,10 +14,6 @@ _log() {
 }
 
 case "$perm_type" in
-	none)
-		# Gentoo needs build system to back off.
-		# https://github.com/iputils/iputils/issues/175
-		;;
 	caps)
 		params="cap_net_raw+p"
 		_log "calling: $setcap $params $exec_path"

--- a/meson.build
+++ b/meson.build
@@ -226,10 +226,7 @@ config_h = configure_file(
 	configuration : conf)
 
 setcap = find_program('setcap', '/usr/sbin/setcap', '/sbin/setcap', required : false)
-if get_option('NO_SETCAP_OR_SUID')
-	perm_type = 'none'
-	setcap_path = '/dev/null'
-elif cap_dep.found() and setcap.found()
+if cap_dep.found() and setcap.found()
 	perm_type = 'caps'
 	setcap_path = setcap.path()
 else
@@ -249,12 +246,14 @@ if build_ping == true
 		dependencies : [m_dep, cap_dep, idn_dep, intl_dep, crypto_dep, resolv_dep],
 		link_with : [libcommon],
 		install: true)
-	meson.add_install_script('build-aux/setcap-setuid.sh',
-		join_paths(get_option('prefix'), get_option('bindir')),
-		'ping',
-		perm_type,
-		setcap_path
-	)
+	if (get_option('SETCAP_OR_SUID_PING') and not get_option('NO_SETCAP_OR_SUID'))
+		meson.add_install_script('build-aux/setcap-setuid.sh',
+			join_paths(get_option('prefix'), get_option('bindir')),
+			'ping',
+			perm_type,
+			setcap_path
+		)
+	endif
 endif
 
 if build_tracepath == true
@@ -269,12 +268,14 @@ if build_traceroute6 == true
 		dependencies : [cap_dep, intl_dep, idn_dep],
 		link_with : [libcommon],
 		install: true)
-	meson.add_install_script('build-aux/setcap-setuid.sh',
-		join_paths(get_option('prefix'), get_option('bindir')),
-		'traceroute6',
-		perm_type,
-		setcap_path
-	)
+	if (get_option('SETCAP_OR_SUID_TRACEROUTE6') and not get_option('NO_SETCAP_OR_SUID'))
+		meson.add_install_script('build-aux/setcap-setuid.sh',
+			join_paths(get_option('prefix'), get_option('bindir')),
+			'traceroute6',
+			perm_type,
+			setcap_path
+		)
+	endif
 endif
 
 if build_clockdiff == true
@@ -282,12 +283,14 @@ if build_clockdiff == true
 		dependencies : [cap_dep, intl_dep],
 		link_with : [libcommon],
 		install: true)
-	meson.add_install_script('build-aux/setcap-setuid.sh',
-		join_paths(get_option('prefix'), get_option('bindir')),
-		'clockdiff',
-		perm_type,
-		setcap_path
-	)
+	if (get_option('SETCAP_OR_SUID_CLOCKDIFF') and not get_option('NO_SETCAP_OR_SUID'))
+		meson.add_install_script('build-aux/setcap-setuid.sh',
+			join_paths(get_option('prefix'), get_option('bindir')),
+			'clockdiff',
+			perm_type,
+			setcap_path
+		)
+	endif
 endif
 
 if build_rinfod == true
@@ -312,12 +315,14 @@ if build_arping == true
 		dependencies : [rt_dep, cap_dep, idn_dep, intl_dep],
 		link_with : [libcommon],
 		install: true)
-	meson.add_install_script('build-aux/setcap-setuid.sh',
-		join_paths(get_option('prefix'), get_option('bindir')),
-		'arping',
-		perm_type,
-		setcap_path
-	)
+	if (get_option('SETCAP_OR_SUID_ARPING') and not get_option('NO_SETCAP_OR_SUID'))
+		meson.add_install_script('build-aux/setcap-setuid.sh',
+			join_paths(get_option('prefix'), get_option('bindir')),
+			'arping',
+			perm_type,
+			setcap_path
+		)
+	endif
 endif
 
 if build_tftpd == true

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,7 +48,19 @@ option('BUILD_HTML_MANS', type : 'boolean', value : false,
 	description : 'Build html manuals')
 
 option('NO_SETCAP_OR_SUID', type : 'boolean', value : false,
-	description : 'Allow disabling build-aux/setcap-setuid.sh')
+       description : 'Disable setting setcap or setuid with build-aux/setcap-setuid.sh')
+
+option('SETCAP_OR_SUID_ARPING', type : 'boolean', value : false,
+	description : 'Set setcap or setuid on arping with build-aux/setcap-setuid.sh')
+
+option('SETCAP_OR_SUID_CLOCKDIFF', type : 'boolean', value : true,
+	description : 'Set setcap or setuid on clockdiff with build-aux/setcap-setuid.sh')
+
+option('SETCAP_OR_SUID_PING', type : 'boolean', value : true,
+	description : 'Set setcap or setuid on ping with build-aux/setcap-setuid.sh')
+
+option('SETCAP_OR_SUID_TRACEROUTE6', type : 'boolean', value : true,
+	description : 'Set setcap or setuid on traceroute6 with build-aux/setcap-setuid.sh')
 
 option('ARPING_DEFAULT_DEVICE', type : 'string', value : '',
 	description : 'Default device for arping')


### PR DESCRIPTION
arping can be used for ARP Poisoning
https://en.wikipedia.org/wiki/ARP_spoofing

Fixes: #203

Signed-off-by: Petr Vorel <pvorel@suse.cz>