### PR TITLE
Makefile: Make all targets phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all clean install dist check
+
 all:
 	ninja -C builddir
 


### PR DESCRIPTION
None of the Makefile targets create a file called like the target.
Therefore all targets are declared to be phony.