### PR TITLE
tracepath: use clock_gettime() rather gettimeofday()

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -268,7 +268,7 @@ static int send_pack(struct run_state *ctl)
 	memcpy(p, &ctl->gdst, 4);
 	p += 4;
 
-	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+	clock_gettime(CLOCK_MONOTONIC, &now);
 	err = sendto(ctl->socketfd, buf, p - buf, 0, (struct sockaddr *)HE, sll_len(ah->ar_hln));
 	if (err == p - buf) {
 		ctl->last = now;
@@ -323,7 +323,7 @@ static int recv_pack(struct run_state *ctl, unsigned char *buf, ssize_t len,
 	unsigned char *p = (unsigned char *)(ah + 1);
 	struct in_addr src_ip, dst_ip;
 
-	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	/* Filter out wild packets */
 	if (FROM->sll_pkttype != PACKET_HOST &&

--- a/tracepath.c
+++ b/tracepath.c
@@ -171,7 +171,7 @@ static int recverr(struct run_state *const ctl)
 	memset(&rcvbuf, -1, sizeof(rcvbuf));
 	msg = reset;
 
-	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 	recv_size = recvmsg(ctl->socket_fd, &msg, MSG_ERRQUEUE);
 	if (recv_size < 0) {
 		if (errno == EAGAIN)
@@ -376,7 +376,7 @@ static int probe_ttl(struct run_state *const ctl)
 			    htons(ctl->base_port + ctl->hisptr);
 			break;
 		}
-		clock_gettime(CLOCK_MONOTONIC_RAW, &hdr->ts);
+		clock_gettime(CLOCK_MONOTONIC, &hdr->ts);
 		ctl->his[ctl->hisptr].hops = ctl->ttl;
 		ctl->his[ctl->hisptr].sendtime = hdr->ts;
 		if (sendto(ctl->socket_fd, ctl->pktbuf, ctl->mtu - ctl->overhead, 0,

--- a/traceroute6.c
+++ b/traceroute6.c
@@ -419,7 +419,7 @@ static void send_probe(struct run_state *ctl, uint32_t seq, int ttl)
 
 	pkt->ident = htonl(ctl->ident);
 	pkt->seq = htonl(seq);
-	clock_gettime(CLOCK_MONOTONIC_RAW, &pkt->ts);
+	clock_gettime(CLOCK_MONOTONIC, &pkt->ts);
 
 	i = setsockopt(ctl->sndsock, SOL_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl));
 	if (i < 0)
@@ -860,10 +860,10 @@ int main(int argc, char **argv)
 			struct timespec t1, t2;
 			struct in6_addr to_addr;
 
-			clock_gettime(CLOCK_MONOTONIC_RAW, &t1);
+			clock_gettime(CLOCK_MONOTONIC, &t1);
 			send_probe(&ctl, ++seq, ttl);
 			while ((cc = wait_for_reply(&ctl, &from, &to_addr, reset_timer)) != 0) {
-				clock_gettime(CLOCK_MONOTONIC_RAW, &t2);
+				clock_gettime(CLOCK_MONOTONIC, &t2);
 				if ((i = packet_ok(&ctl, cc, &from, &to_addr, seq, &t1))) {
 					if (memcmp(&from.sin6_addr, &lastaddr,
 						   sizeof(from.sin6_addr))) {


### PR DESCRIPTION
The gettimeofday() is obsolete.  Secondly, ensure time jumps do not effect
measurements by using monotonic time.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>