### PR TITLE
More gettimeofday removals

### DIFF
--- a/iputils_common.h
+++ b/iputils_common.h
@@ -59,5 +59,6 @@ extern int close_stream(FILE *stream);
 extern void close_stdout(void);
 extern long strtol_or_err(char const *const str, char const *const errmesg,
 			  const long min, const long max);
+extern void iputils_srand(void);
 
 #endif /* IPUTILS_COMMON_H */

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ conf.set('_GNU_SOURCE', 1, description : 'Enable GNU extensions on systems that 
 # Check functions.
 foreach f : '''
 	__fpending
+	getrandom
 	nanosleep
 '''.split()
 	if cc.has_function(f, args : '-D_GNU_SOURCE')

--- a/ninfod/ninfod_core.c
+++ b/ninfod/ninfod_core.c
@@ -305,21 +305,7 @@ void init_core(int forced)
 	DEBUG(LOG_DEBUG, "%s()\n", __func__);
 
 	if (!initialized || forced) {
-		struct timeval tv;
-		unsigned int seed = 0;
-		pid_t pid;
-
-		if (gettimeofday(&tv, NULL) < 0) {
-			DEBUG(LOG_WARNING, "%s(): failed to gettimeofday()\n", __func__);
-		} else {
-			seed = (tv.tv_usec & 0xffffffff);
-		}
-
-		pid = getpid();
-		seed ^= (((unsigned long)pid) & 0xffffffff);
-
-		srand(seed);
-
+		iputils_srand();
 #if ENABLE_THREADS
 		if (initialized)
 			pthread_attr_destroy(&pattr);

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -176,14 +176,7 @@ struct {
 static void niquery_init_nonce(void)
 {
 #if PING6_NONCE_MEMORY
-	struct timeval tv;
-	unsigned long seed;
-
-	seed = (unsigned long)getpid();
-	if (!gettimeofday(&tv, NULL))
-		seed ^= tv.tv_usec;
-	srand(seed);
-
+	iputils_srand();
 	ni_nonce_ptr = calloc(NI_NONCE_SIZE, MAX_DUP_CHK);
 	if (!ni_nonce_ptr)
 		error(2, errno, "calloc");

--- a/rdisc.c
+++ b/rdisc.c
@@ -419,7 +419,7 @@ next:
 
 #ifdef RDISC_SERVER
 	if (responder)
-		srandom((int)gethostid());
+		iputils_srand();
 #endif
 
 	if ((s = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) < 0) {
@@ -503,7 +503,7 @@ void timer()
 		else
 			left_until_advertise = min_adv_int +
 				((max_adv_int - min_adv_int) *
-				 (random() % 1000)/1000);
+				 (rand() % 1000)/1000);
 	} else
 #endif
 	if (solicit && left_until_solicit <= 0) {
@@ -873,7 +873,7 @@ pr_pack(char *buf, int cc, struct sockaddr_in *from)
 			/* Restart the timer when we broadcast */
 			left_until_advertise = min_adv_int +
 				((max_adv_int - min_adv_int)
-				 * (random() % 1000)/1000);
+				 * (rand() % 1000)/1000);
 		} else {
 			sin.sin_addr.s_addr = ip->saddr;
 			if (!is_directly_connected(sin.sin_addr)) {


### PR DESCRIPTION
Hi @pevik sorry if you already spent dev time with clockdiff(8) gettimeofday(2) removal. I had a look of that change, and it decided see if I could get the change done. See the 72e5aae53d471fc3a94cf30504d413d32a4772ca for results, that also makes use of ppoll(2) rather than select(2) to avoid unnecessary time unit conversions. When asking if you could have a look I did not realise there was also need to fix file descriptor wait code.

Anyway, here's some changes. Would be great if you could have a quick look.