### PR TITLE
More gettimeofday removals

### DIFF
--- a/iputils_common.c
+++ b/iputils_common.c
@@ -119,3 +119,14 @@ void iputils_srand(void)
 		i--;
 	}
 }
+
+void timespecsub(struct timespec *a, struct timespec *b, struct timespec *res)
+{
+	res->tv_sec = a->tv_sec - b->tv_sec;
+	res->tv_nsec = a->tv_nsec - b->tv_nsec;
+
+	if (res->tv_nsec < 0) {
+		res->tv_sec--;
+		res->tv_nsec += 1000000000L;
+	}
+}

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -59,5 +59,6 @@ extern int close_stream(FILE *stream);
 extern void close_stdout(void);
 extern long strtol_or_err(char const *const str, char const *const errmesg,
 			  const long min, const long max);
+extern void iputils_srand(void);
 
 #endif /* IPUTILS_COMMON_H */

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -60,5 +60,7 @@ extern void close_stdout(void);
 extern long strtol_or_err(char const *const str, char const *const errmesg,
 			  const long min, const long max);
 extern void iputils_srand(void);
+extern void timespecsub(struct timespec *a, struct timespec *b,
+			struct timespec *res);
 
 #endif /* IPUTILS_COMMON_H */

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ conf.set('_GNU_SOURCE', 1, description : 'Enable GNU extensions on systems that 
 # Check functions.
 foreach f : '''
 	__fpending
+	getrandom
 	nanosleep
 '''.split()
 	if cc.has_function(f, args : '-D_GNU_SOURCE')

--- a/ninfod/ninfod_core.c
+++ b/ninfod/ninfod_core.c
@@ -382,26 +382,26 @@ static int ni_send_fork(struct packetcontext *p)
 
 static int ni_ratelimit(void)
 {
-	static struct timeval last;
-	struct timeval tv, sub;
+	static struct timespec last = { 0 };
+	struct timespec now, sub;
 
-	if (gettimeofday(&tv, NULL) < 0) {
-		DEBUG(LOG_WARNING, "%s(): gettimeofday(): %s\n",
+	if (clock_gettime(CLOCK_MONOTONIC, &now) < 0) {
+		DEBUG(LOG_WARNING, "%s(): clock_gettime(): %s\n",
 		      __func__, strerror(errno));
 		return -1;
 	}
 
-	if (!timerisset(&last)) {
-		last = tv;
+	if (!(last.tv_sec || last.tv_nsec)) {
+		last = now;
 		return 0;
 	}
 
-	timersub(&tv, &last, &sub);
+	timespecsub(&now, &last, &sub);
 
 	if (sub.tv_sec < 1)
 		return 1;
 
-	last = tv;
+	last = now;
 	return 0;
 }
 

--- a/ninfod/ninfod_core.c
+++ b/ninfod/ninfod_core.c
@@ -305,21 +305,7 @@ void init_core(int forced)
 	DEBUG(LOG_DEBUG, "%s()\n", __func__);
 
 	if (!initialized || forced) {
-		struct timeval tv;
-		unsigned int seed = 0;
-		pid_t pid;
-
-		if (gettimeofday(&tv, NULL) < 0) {
-			DEBUG(LOG_WARNING, "%s(): failed to gettimeofday()\n", __func__);
-		} else {
-			seed = (tv.tv_usec & 0xffffffff);
-		}
-
-		pid = getpid();
-		seed ^= (((unsigned long)pid) & 0xffffffff);
-
-		srand(seed);
-
+		iputils_srand();
 #if ENABLE_THREADS
 		if (initialized)
 			pthread_attr_destroy(&pattr);

--- a/ping6_common.c
+++ b/ping6_common.c
@@ -176,14 +176,7 @@ struct {
 static void niquery_init_nonce(void)
 {
 #if PING6_NONCE_MEMORY
-	struct timeval tv;
-	unsigned long seed;
-
-	seed = (unsigned long)getpid();
-	if (!gettimeofday(&tv, NULL))
-		seed ^= tv.tv_usec;
-	srand(seed);
-
+	iputils_srand();
 	ni_nonce_ptr = calloc(NI_NONCE_SIZE, MAX_DUP_CHK);
 	if (!ni_nonce_ptr)
 		error(2, errno, "calloc");

--- a/rdisc.c
+++ b/rdisc.c
@@ -419,7 +419,7 @@ next:
 
 #ifdef RDISC_SERVER
 	if (responder)
-		srandom((int)gethostid());
+		iputils_srand();
 #endif
 
 	if ((s = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) < 0) {
@@ -503,7 +503,7 @@ void timer()
 		else
 			left_until_advertise = min_adv_int +
 				((max_adv_int - min_adv_int) *
-				 (random() % 1000)/1000);
+				 (rand() % 1000)/1000);
 	} else
 #endif
 	if (solicit && left_until_solicit <= 0) {
@@ -873,7 +873,7 @@ pr_pack(char *buf, int cc, struct sockaddr_in *from)
 			/* Restart the timer when we broadcast */
 			left_until_advertise = min_adv_int +
 				((max_adv_int - min_adv_int)
-				 * (random() % 1000)/1000);
+				 * (rand() % 1000)/1000);
 		} else {
 			sin.sin_addr.s_addr = ip->saddr;
 			if (!is_directly_connected(sin.sin_addr)) {

--- a/tracepath.c
+++ b/tracepath.c
@@ -41,18 +41,6 @@
 # define getnameinfo_flags	0
 #endif
 
-#ifndef timespecsub
-#define timespecsub(tsp, usp, vsp)					\
-	do {								\
-		(vsp)->tv_sec = (tsp)->tv_sec - (usp)->tv_sec;		\
-		(vsp)->tv_nsec = (tsp)->tv_nsec - (usp)->tv_nsec;	\
-		if ((vsp)->tv_nsec < 0) {				\
-			(vsp)->tv_sec--;				\
-			(vsp)->tv_nsec += 1000000000L;			\
-		}							\
-	} while (0)
-#endif
-
 enum {
 	MAX_PROBES = 10,
 


### PR DESCRIPTION
Follow up to pull requests #213 & #214. In this revision feedback mostly from #214 is added to commits, and clockdiff(8) commit message has couple words why ppoll(2) replaced select(2) calls.

If I don't hear anything by Sunday 2019-09-15 I will just merge these change. I am optimistic most of the review already happen in couple earlier pulls.