### PR TITLE
ping: use random value for the identifier field

### DIFF
--- a/ping/node_info.c
+++ b/ping/node_info.c
@@ -93,7 +93,6 @@ int niquery_is_enabled(struct ping_ni *ni)
 void niquery_init_nonce(struct ping_ni *ni)
 {
 #if PING6_NONCE_MEMORY
-	iputils_srand();
 	ni->nonce_ptr = calloc(NI_NONCE_SIZE, MAX_DUP_CHK);
 	if (!ni->nonce_ptr)
 		error(2, errno, "calloc");

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -501,6 +501,8 @@ main(int argc, char **argv)
 	if (!argc)
 		error(1, EDESTADDRREQ, "usage error");
 
+	iputils_srand();
+
 	target = argv[argc - 1];
 
 	rts.outpack = malloc(rts.datalen + 28);
@@ -1394,7 +1396,7 @@ in_cksum(const unsigned short *addr, int len, unsigned short csum)
 /*
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
- * will be added on by the kernel.  The ID field is our UNIX process ID,
+ * will be added on by the kernel.  The ID field is a random number,
  * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -145,7 +145,7 @@ struct ping_rts {
 	size_t datalen;
 	char *hostname;
 	uid_t uid;
-	int ident;			/* process id to identify our packets */
+	int ident;			/* random id to identify our packets */
 
 	int sndbuf;
 	int ttl;

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -550,7 +550,7 @@ out:
 /*
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
- * will be added on by the kernel.  The ID field is our UNIX process ID,
+ * will be added on by the kernel.  The ID field is a random number,
  * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -296,7 +296,7 @@ void print_timestamp(struct ping_rts *rts)
 /*
  * pinger --
  * 	Compose and transmit an ICMP ECHO REQUEST packet.  The IP packet
- * will be added on by the kernel.  The ID field is our UNIX process ID,
+ * will be added on by the kernel.  The ID field is a random number,
  * and the sequence number is an ascending integer.  The first several bytes
  * of the data portion are used to hold a UNIX "timeval" struct in VAX
  * byte-order, to compute the round-trip time.
@@ -521,7 +521,7 @@ void setup(struct ping_rts *rts, socket_st *sock)
 	}
 
 	if (sock->socktype == SOCK_RAW)
-		rts->ident = htons(getpid() & 0xFFFF);
+		rts->ident = rand() & 0xFFFF;
 
 	set_signal(SIGINT, sigexit);
 	set_signal(SIGALRM, sigexit);


### PR DESCRIPTION
ping historycally used to fill the Identifier field (see RFC 792) with
its PID:

    # tcpdump -tnni lo icmp &

    # ping -q 127.0.0.1 &
    PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
    IP 127.0.0.1 > 127.0.0.1: ICMP echo request, id 347, seq 1, length 64
    IP 127.0.0.1 > 127.0.0.1: ICMP echo reply, id 347, seq 1, length 64
    IP 127.0.0.1 > 127.0.0.1: ICMP echo request, id 347, seq 2, length 64
    IP 127.0.0.1 > 127.0.0.1: ICMP echo reply, id 347, seq 2, length 64

    # ps 347
      PID TTY      STAT   TIME COMMAND
      347 hvc0     S      0:00 ping -q 127.0.0.1

This can be seen as an information leak, let's use a random number as id.

Signed-off-by: Matteo Croce <mcroce@redhat.com>