### PR TITLE
ninfod: Fix meson warning about 'install' arg in 'configure_file'

### DIFF
--- a/ninfod/meson.build
+++ b/ninfod/meson.build
@@ -31,6 +31,5 @@ else
 	configure_file(input : 'ninfod.sh.in',
 		output : 'ninfod.sh',
 		configuration : conf_data,
-		install : true,
 		install_dir : join_paths(get_option('sysconfdir'), 'init.d'))
 endif


### PR DESCRIPTION
We claim to support 0.39, but install: argument in configure_file was
introduced in version 0.50. This produces the following meson warning:

WARNING: Project specifies a minimum meson_version '>=0.39' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}

From the doc for the install argument [1]:
" When omitted it (install) defaults to true when install_dir is set and
not empty, false otherwise."

Therefore remove install: argument and just depend on install_dir for installing.

[1] https://mesonbuild.com/Reference-manual.html#configure_file

Fixes: 9244bd0 ("build-sys: make meson to do everything needed")

Signed-off-by: Petr Vorel <petr.vorel@gmail.com>