### PR TITLE
Fixing url error

### DIFF
--- a/systemd/ninfod.service.in
+++ b/systemd/ninfod.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Respond to IPv6 Node Information Queries
-Documentation=ninfod(8)
+Documentation=man:ninfod(8)
 Requires=network.target
 After=network.target
 


### PR DESCRIPTION
systemd[1]: /usr/lib/systemd/system/ninfod.service:3: Invalid URL, ignoring: ninfod(8)