### PR TITLE
ping6: missing init of v6 socket address family

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -277,6 +277,7 @@ main(int argc, char **argv)
 #endif
 		.pmtudisc = -1,
 		.source.sin_family = AF_INET,
+		.source6.sin6_family = AF_INET6,
 		.ni.query = -1,
 		.ni.subject_type = -1,
 	};


### PR DESCRIPTION
socket bind fails if the IPv6 source address family is not
initialised to AF_INET6.

Signed-off-by: Patrick Ruddy <pruddy@vyatta.att-mail.com>