### PR TITLE
ping: allow -i and -W option arguments contain garbage input

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -184,8 +184,10 @@ static double ping_strtod(const char *str, const char *err_msg)
 #ifdef USE_IDN
 	setlocale(LC_ALL, "");
 #endif
-	if (errno || str == end || (end && *end))
-		goto err;
+	if (errno || str == end || (end && *end)) {
+		error(0, 0, _("option argument contains garbage: %s"), end);
+		error(0, 0, _("this will become fatal error in future"));
+	}
 	switch (fpclassify(num)) {
 	case FP_NORMAL:
 	case FP_ZERO:


### PR DESCRIPTION
Earlier 'ping -W 1s ...' worked without complaints, but the user interface
regression broke that.  Notice that none-numeric value was simply ignored,
so '-W 1s' and and '-W 1h' meant the same although they looked different.
That was misleading, but because values still managed to work for next
couple releases accepting number with garbage at end is re-introduced.

Regression-since; 918e824dc13a39e4d68fcd82fd2d248c9fba6bbd
Addresses: https://github.com/iputils/iputils/issues/236
Signed-off-by: Sami Kerola <kerolasa@iki.fi>