### PR TITLE
nodeinfo: warn if random nonce generation fails

### DIFF
--- a/iputils_md5dig.h
+++ b/iputils_md5dig.h
@@ -103,10 +103,14 @@ static void iputils_md5dig_init(iputils_md5dig_ctx *const ctx)
 	};
 
 	ctx->comm_sock = -1;
-	if ((ctx->bind_sock = socket(AF_ALG, SOCK_SEQPACKET, 0)) < 0)
+	if ((ctx->bind_sock = socket(AF_ALG, SOCK_SEQPACKET, 0)) < 0) {
+		error(0, errno, "WARNING: kernel crypto API socket() failed");
 		return;
-	if (bind(ctx->bind_sock, (struct sockaddr *)&sa, sizeof(sa)) < 0)
+	}
+	if (bind(ctx->bind_sock, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+		error(0, errno, "WARNING: kernel crypto API bind() failed");
 		return;
+	}
 	ctx->comm_sock = accept(ctx->bind_sock, NULL, 0);
 	return;
 }


### PR DESCRIPTION
If using the kernel crypto API, but MD5 algorithm support is unavailable,
nodeinfo queries may contain a predictable nonce value. Warn the user via
stderr if this happens.

This is a proposed fix for #239. Open questions:

 * Do we want to warn only once when starting?
 * Should we exit, instead of continuing?