### PR TITLE
meson.build: fix static build with libidn2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ endif
 
 idn = get_option('USE_IDN')
 if idn == true
-	idn_dep = cc.find_library('idn2', required : false)
+	idn_dep = dependency('libidn2', required : false)
 	if idn_dep.found()
 		add_project_arguments('-DUSE_IDN', language : 'c')
 		conf.set('USE_IDN', 1,


### PR DESCRIPTION
libidn2 can optionnaly depends on libunistring so use dependency
function instead of cc.find_library ro retrieve this dependency and
avoid the following build failure when building statically:

```
FAILED: ping
/home/buildroot/autobuild/run/instance-1/output-1/host/bin/arm-linux-gcc  -o ping 'ping@exe/ping.c.o' 'ping@exe/ping_common.c.o' 'ping@exe/ping6_common.c.o' -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -static -Wl,--start-group libcommon.a -lm -lcap -lidn2 /home/buildroot/autobuild/run/instance-1/output-1/host/usr/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libssl.a /home/buildroot/autobuild/run/instance-1/output-1/host/usr/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libz.a /home/buildroot/autobuild/run/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/7.4.0/../../../../arm-buildroot-linux-uclibcgnueabi/lib/libatomic.a -lpthread /home/buildroot/autobuild/run/instance-1/output-1/host/usr/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libcrypto.a -lresolv -Wl,--end-group '-Wl,-rpath,$ORIGIN/' -Wl,-rpath-link,/home/buildroot/autobuild/run/instance-1/output-1/build/iputils-20190709/build/
/home/buildroot/autobuild/run/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/7.4.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: /home/buildroot/autobuild/run/instance-1/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libidn2.a(lookup.o): in function `idn2_lookup_u8':
lookup.c:(.text+0x7c): undefined reference to `u8_strlen'

```
Fixes:
 - http://autobuild.buildroot.org/results/82d4738711a009959436fa419bd78c7a9540d33e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>