### PR TITLE
ping: Fix inconsistent usage of decimals when reporting times.

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -810,9 +810,9 @@ restamp:
 			return 1;
 		}
 		if (rts->timing) {
-			if (triptime >= 100000)
+			if (triptime >= 100000 - 50)
 				printf(_(" time=%ld ms"), (triptime + 500) / 1000);
-			else if (triptime >= 10000)
+			else if (triptime >= 10000 - 5)
 				printf(_(" time=%ld.%01ld ms"), (triptime + 50) / 1000,
 				       ((triptime + 50) % 1000) / 100);
 			else if (triptime >= 1000)


### PR DESCRIPTION
The code switches from 3 to 4 significant digits because
of mismanaged rounding effects.

Example:
```
µseconds  ORIGINAL CODE        PATCHED CODE

 9993  time=9.99 ms          9993  time=9.99 ms
 9994  time=9.99 ms          9994  time=9.99 ms
 9995  time=10.00 ms     |   9995  time=10.0 ms
 9996  time=10.00 ms     |   9996  time=10.0 ms

 9998  time=10.00 ms     |   9998  time=10.0 ms
 9999  time=10.00 ms     |   9999  time=10.0 ms
10000  time=10.0 ms         10000  time=10.0 ms
10001  time=10.0 ms         10001  time=10.0 ms
```