### PR TITLE
ping: fix ping6 name resolution for hostnames with link-local addresses

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -544,11 +544,29 @@ main(int argc, char **argv)
 	if (rts.tclass)
 		set_socket_option(&sock6, IPPROTO_IPV6, IPV6_TCLASS, &rts.tclass, sizeof rts.tclass);
 
+	/* getaddrinfo fails to indicate a scopeid when not used in dual-stack mode.
+	 * Work around by always using dual-stack name resolution.
+	 *
+	 * https://github.com/iputils/iputils/issues/252
+	 */
+	int target_ai_family = hints.ai_family;
+	hints.ai_family = AF_UNSPEC;
+
 	ret_val = getaddrinfo(target, NULL, &hints, &result);
 	if (ret_val)
 		error(2, 0, "%s: %s", target, gai_strerror(ret_val));
 
 	for (ai = result; ai; ai = ai->ai_next) {
+		if (target_ai_family != AF_UNSPEC &&
+			target_ai_family != ai->ai_family) {
+			if (!ai->ai_next) {
+				/* An address was found, but not of the family we really want.
+				 * Throw the appropriate gai error.
+				 */
+				error(2, 0, "%s: %s", target, gai_strerror(EAI_ADDRFAMILY));
+			}
+			continue;
+		}
 		switch (ai->ai_family) {
 		case AF_INET:
 			ret_val = ping4_run(&rts, argc, argv, ai, &sock4);


### PR DESCRIPTION
Fixes: #252 

This implements my second suggestion from the issue, which I believe is the least disruptive.
Commit message follows. PTAL.

---

getaddrinfo has several potential interfaces it can use to fulfill hostname
requests with the nss, namely nss_gethostbyname{,2,3,4}_r. It selects
which interface to choose based on the passed hints. Unfortunately, the
only interface with the potential to indicate an appropriate scope id
for link-local IPv6 addresses is nss_gethostbyname4_r, which is
necessarily dual-stack. As a result, getaddrinfo avoids that interface
when the requested address family is not AF_UNSPEC causing ping6
requests to fail for hostnames that resolve to link-local addresses
because of an unspecified scope id, even when they could succeed in the
dual-stack case.

This is a problem when using a local resolver such as systemd-resolved
that synthesizes resource records in some cases containing link-local
addresses. Although `ping -6 _gateway` seems like an appropriate test
for IPv6 connectivity, it fails for the above reason.

This commit causes ping to always request the dual-stack name resolution
behavior, even when it intends only to ping IPv6 hosts. If name
resolution returns an addrinfo list that does not contain an address
from the appropriate family, it intentionally fails with EAI_ADDRFAMILY.