### PR TITLE
ping: print the gateway with the correct endianness

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1221,7 +1221,7 @@ static void pr_icmph(struct ping_rts *rts, uint8_t type, uint8_t code,
 			struct sockaddr_in sin = {
 				.sin_family = AF_INET,
 				.sin_addr =  {
-					icp ? icp->un.gateway : info
+					icp ? icp->un.gateway : htonl(info)
 				}
 			};
 


### PR DESCRIPTION
When receiving an ICMP redirect message, ping prints the nexthop,
but this is shown with the wrong endianness on x86:

    $ ping 192.168.0.1
    PING 192.168.0.1 (192.168.0.1) 56(84) bytes of data.
    64 bytes from 192.168.0.1: icmp_seq=1 ttl=254 time=3.41 ms
    From 192.168.85.1 icmp_seq=2 Redirect Host(New nexthop: 44.85.168.192)
    64 bytes from 192.168.0.1: icmp_seq=2 ttl=254 time=3.75 ms

This only happens when using IPPROTO_ICMP sockets, with raw sockets the
issue doesn't happen:

    $ sudo sysctl -w net.ipv4.ping_group_range='1 0'
    net.ipv4.ping_group_range = 1 0

    $ sudo ping 192.168.0.1
    PING 192.168.0.1 (192.168.0.1) 56(84) bytes of data.
    64 bytes from 192.168.0.1: icmp_seq=1 ttl=254 time=3.17 ms
    From 192.168.85.1: icmp_seq=2 Redirect Host(New nexthop: 192.168.85.44)
    64 bytes from 192.168.0.1: icmp_seq=2 ttl=254 time=3.79 ms

Signed-off-by: Matteo Croce <mcroce@redhat.com>