### PR TITLE
Put IPv6 header NextHeader field definitions into header

### DIFF
--- a/ipv6.h
+++ b/ipv6.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2020 Petr Vorel <petr.vorel@gmail.com>
+ */
+
+#ifndef IPV6_H
+#define IPV6_H
+
+/* Definitions from kernel include/net/ipv6.h */
+
+/*
+ *	NextHeader field of IPv6 header
+ */
+
+#define NEXTHDR_HOP		0	/* Hop-by-hop option header. */
+#define NEXTHDR_TCP		6	/* TCP segment. */
+#define NEXTHDR_UDP		17	/* UDP message. */
+#define NEXTHDR_IPV6		41	/* IPv6 in IPv6 */
+#define NEXTHDR_ROUTING		43	/* Routing header. */
+#define NEXTHDR_FRAGMENT	44	/* Fragmentation/reassembly header. */
+#define NEXTHDR_GRE		47	/* GRE header. */
+#define NEXTHDR_ESP		50	/* Encapsulating security payload. */
+#define NEXTHDR_AUTH		51	/* Authentication header. */
+#define NEXTHDR_ICMP		58	/* ICMP for IPv6. */
+#define NEXTHDR_NONE		59	/* No next header */
+#define NEXTHDR_DEST		60	/* Destination options header. */
+#define NEXTHDR_SCTP		132	/* SCTP message. */
+#define NEXTHDR_MOBILITY	135	/* Mobility header. */
+
+#endif /* IPV6_H */

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -60,6 +60,7 @@
 #include <stddef.h>
 #include "iputils_common.h"
 #include "iputils_ni.h"
+#include "ipv6.h"
 #include "ping.h"
 
 ping_func_set_st ping6_func_set = {
@@ -861,7 +862,7 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 
 		nexthdr = iph1->ip6_nxt;
 
-		if (nexthdr == 44) {
+		if (nexthdr == NEXTHDR_FRAGMENT) {
 			nexthdr = *(uint8_t *)icmph1;
 			icmph1++;
 		}

--- a/traceroute6.c
+++ b/traceroute6.c
@@ -253,6 +253,7 @@
 #endif
 
 #include "iputils_common.h"
+#include "ipv6.h"
 
 #ifdef USE_IDN
 # define ADDRINFO_IDN_FLAGS	AI_IDN
@@ -531,7 +532,7 @@ static int packet_ok(struct run_state *ctl, int cc, struct sockaddr_in6 *from,
 		up = (struct udphdr *)(hip + 1);
 		nexthdr = hip->ip6_nxt;
 
-		if (nexthdr == 44) {
+		if (nexthdr == NEXTHDR_FRAGMENT) {
 			nexthdr = *(unsigned char *)up;
 			up++;
 		}


### PR DESCRIPTION
Instead of hardwire 43 and 44 constants, it's better to copy the
definitions from include/net/ipv6.h from kernel.

Signed-off-by: Petr Vorel <petr.vorel@gmail.com>