### PR TITLE
ping: Use C locale for parsing -i/-W without IDN

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -177,13 +177,11 @@ static double ping_strtod(const char *str, const char *err_msg)
 	if (str == NULL || *str == '\0')
 		goto err;
 	errno = 0;
-#ifdef USE_IDN
+
 	setlocale(LC_ALL, "C");
-#endif
 	num = strtod(str, &end);
-#ifdef USE_IDN
 	setlocale(LC_ALL, "");
-#endif
+
 	if (errno || str == end || (end && *end)) {
 		error(0, 0, _("option argument contains garbage: %s"), end);
 		error(0, 0, _("this will become fatal error in future"));


### PR DESCRIPTION
There is no reason to only use C local, if IDN is used.
The parameters have nothing to do with IDN and iputils might
be compiled without IDN support (e.g. on ubuntu), this should not
affect -i and -W

Signed-off-by: Joerg Vehlow <joerg.vehlow@aox-tech.de>