### PR TITLE
ping: strictsource option not set when using -B

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -358,7 +358,7 @@ main(int argc, char **argv)
 			rts.opt_adaptive = 1;
 			break;
 		case 'B':
-			rts.opt_sourceroute = 1;
+			rts.opt_strictsource = 1;
 			break;
 		case 'c':
 			rts.npackets = strtol_or_err(optarg, _("invalid argument"), 1, LONG_MAX);


### PR DESCRIPTION
Since b3a41a6ed616176dba4b556fc0d90355513447e9 presence of the -B
option has caused the strictroute flag to be set instead of
strictsource.

Signed-off-by: Duncan Eastoe <duncan.eastoe@att.com>