### PR TITLE
WIP: Use plural form in arping

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -282,16 +282,28 @@ static int send_pack(struct run_state *ctl)
 static int finish(struct run_state *ctl)
 {
 	if (!ctl->quiet) {
-		printf(_("Sent %d probes (%d broadcast(s))\n"), ctl->sent, ctl->brd_sent);
-		printf(_("Received %d response(s)"), ctl->received);
+		printf(ngettext("Sent %d probe",
+						"Sent %d probes",
+						ctl->sent));
+		printf(" ");
+		printf(ngettext("(%d broadcast)\n",
+						"(%d broadcasts)\n",
+						ctl->brd_sent));
+		printf(ngettext("Received %d response",
+						"Received %d responses",
+						ctl->received));
 		if (ctl->brd_recv || ctl->req_recv) {
 			printf(" (");
 			if (ctl->req_recv)
-				printf(_("%d request(s)"), ctl->req_recv);
-			if (ctl->brd_recv)
-				printf(_("%s%d broadcast(s)"),
-				       ctl->req_recv ? ", " : "",
-				       ctl->brd_recv);
+				printf(ngettext("%d request",
+								"%d requests",
+								ctl->req_recv));
+			if (ctl->brd_recv) {
+				printf("%s",ctl->req_recv ? ", " : "");
+				printf(ngettext("%d broadcast",
+								"%d broadcasts",
+								ctl->brd_recv));
+			}
 			printf(")");
 		}
 		printf("\n");

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,7 +1,8 @@
 arping.c
 clockdiff.c
-ping.c
-ping_common.c
-ping6_common.c
+ping/node_info.c
+ping/ping6_common.c
+ping/ping.c
+ping/ping_common.c
 tracepath.c
 traceroute6.c

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-09 19:20+0000\n"
+"POT-Creation-Date: 2020-06-29 11:58-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,85 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#: ping/ping.c:1081
-#, c-format
-msgid "\t%ld absolute"
-msgstr ""
-
-#: ping/ping.c:1075
-#, c-format
-msgid "\t%ld absolute not-standard"
-msgstr ""
-
-#: ping/ping.c:1077
-#, c-format
-msgid "\t%ld not-standard"
-msgstr ""
-
-#: ping/ping.c:1002
-#, c-format
-msgid "\t(same route)"
-msgstr ""
-
-#: arping.c:132
-#, c-format
-msgid ""
-"\n"
-"  -s <source>   source ip address\n"
-"  <destination> dns name or ip address\n"
-"\n"
-"For more details see arping(8).\n"
-msgstr ""
-
-#: ping/ping.c:964
-#, c-format
-msgid ""
-"\n"
-"%cSRR: "
-msgstr ""
-
-#: ping/ping.c:953
-#, c-format
-msgid ""
-"\n"
-"NOP"
-msgstr ""
-
-#: ping/ping.c:1007
-#, c-format
-msgid ""
-"\n"
-"RR: "
-msgstr ""
-
-#: ping/ping.c:1043
-#, c-format
-msgid ""
-"\n"
-"TS: "
-msgstr ""
-
-#: tracepath.c:398
-#, c-format
-msgid ""
-"\n"
-"Usage\n"
-"  tracepath [options] <destination>\n"
-"\n"
-"Options:\n"
-"  -4             use IPv4\n"
-"  -6             use IPv6\n"
-"  -b             print both name and ip\n"
-"  -l <length>    use packet <length>\n"
-"  -m <hops>      use maximum <hops>\n"
-"  -n             no dns name resolution\n"
-"  -p <port>      use destination <port>\n"
-"  -V             print version and exit\n"
-"  <destination>  dns name or ip address\n"
-"\n"
-"For more details see tracepath(8).\n"
-msgstr ""
 
 #: arping.c:113
 #, c-format
@@ -117,6 +38,150 @@ msgid ""
 "  -I <device>   which ethernet device to use"
 msgstr ""
 
+#: arping.c:132
+#, c-format
+msgid ""
+"\n"
+"  -s <source>   source ip address\n"
+"  <destination> dns name or ip address\n"
+"\n"
+"For more details see arping(8).\n"
+msgstr ""
+
+#: arping.c:285
+#, c-format
+msgid "Sent %d probes (%d broadcast(s))\n"
+msgstr ""
+
+#: arping.c:286
+#, c-format
+msgid "Received %d response(s)"
+msgstr ""
+
+#: arping.c:290
+#, c-format
+msgid "%d request(s)"
+msgstr ""
+
+#: arping.c:292
+#, c-format
+msgid "%s%d broadcast(s)"
+msgstr ""
+
+#: arping.c:387
+msgid "Unicast"
+msgstr ""
+
+#: arping.c:387
+msgid "Broadcast"
+msgstr ""
+
+#: arping.c:388
+#, c-format
+msgid "%s from "
+msgstr ""
+
+#: arping.c:388
+msgid "reply"
+msgstr ""
+
+#: arping.c:388
+msgid "request"
+msgstr ""
+
+#: arping.c:393
+#, c-format
+msgid "for %s "
+msgstr ""
+
+#: arping.c:398
+#, c-format
+msgid "for "
+msgstr ""
+
+#: arping.c:408
+#, c-format
+msgid " %ld.%03ldms\n"
+msgstr ""
+
+#: arping.c:410
+#, c-format
+msgid " UNSOLICITED?\n"
+msgstr ""
+
+#: arping.c:561
+#, c-format
+msgid "Interface \"%s\" is down\n"
+msgstr ""
+
+#: arping.c:569
+#, c-format
+msgid "Interface \"%s\" is not ARPable\n"
+msgstr ""
+
+#: arping.c:662
+#, c-format
+msgid "WARNING: using default broadcast address.\n"
+msgstr ""
+
+#: arping.c:872 arping.c:875 arping.c:878 ping/ping.c:364 ping/ping.c:410
+#: ping/ping.c:418 ping/ping.c:460 ping/ping.c:463 ping/ping.c:466
+#: ping/ping.c:479 tracepath.c:472 tracepath.c:475 tracepath.c:478
+#: tracepath.c:499 traceroute6.c:688 traceroute6.c:694 traceroute6.c:697
+msgid "invalid argument"
+msgstr ""
+
+#: arping.c:944
+#, c-format
+msgid "Device %s not available."
+msgstr ""
+
+#: arping.c:945
+msgid "Suitable device could not be determined. Please, use option -I."
+msgstr ""
+
+#: arping.c:965 traceroute6.c:822
+msgid "WARNING: interface is ignored"
+msgstr ""
+
+#: arping.c:983
+msgid "WARNING: setsockopt(SO_DONTROUTE)"
+msgstr ""
+
+#: arping.c:1006
+#, c-format
+msgid "Interface \"%s\" is not ARPable (no ll address)\n"
+msgstr ""
+
+#: arping.c:1015
+#, c-format
+msgid "ARPING %s "
+msgstr ""
+
+#: arping.c:1016
+#, c-format
+msgid "from %s %s\n"
+msgstr ""
+
+#: arping.c:1020
+msgid "no source address in not-DAD mode"
+msgstr ""
+
+#: clockdiff.c:240
+#, c-format
+msgid "Wrong timestamp %d\n"
+msgstr ""
+
+#: clockdiff.c:245
+#, c-format
+msgid "Overflow %d hops\n"
+msgstr ""
+
+#: clockdiff.c:270
+#, c-format
+msgid "wrong timestamps\n"
+msgstr ""
+
 #: clockdiff.c:451
 #, c-format
 msgid ""
@@ -136,6 +201,1193 @@ msgid ""
 "  <destination> dns name or ip address\n"
 "\n"
 "For more details see clockdiff(8).\n"
+msgstr ""
+
+#: clockdiff.c:589
+msgid "measure: unknown failure"
+msgstr ""
+
+#: clockdiff.c:594
+#, c-format
+msgid "%s is down"
+msgstr ""
+
+#: clockdiff.c:597
+#, c-format
+msgid "%s time transmitted in a non-standard format"
+msgstr ""
+
+#: clockdiff.c:600
+#, c-format
+msgid "%s is unreachable"
+msgstr ""
+
+#: clockdiff.c:618
+#, c-format
+msgid ""
+"\n"
+"host=%s rtt=%ld(%ld)ms/%ldms delta=%dms/%dms %s"
+msgstr ""
+
+#: ping/node_info.c:166
+#, c-format
+msgid "Qtype conflict\n"
+msgstr ""
+
+#: ping/node_info.c:218
+#, c-format
+msgid "Subject type conflict\n"
+msgstr ""
+
+#: ping/node_info.c:309
+#, c-format
+msgid "IDN encoding error: %s"
+msgstr ""
+
+#: ping/node_info.c:320
+msgid "too long scope name"
+msgstr ""
+
+#: ping/node_info.c:344 ping/node_info.c:386 ping/ping6_common.c:266
+#: ping/ping.c:447 ping/ping.c:510 ping/ping.c:920
+msgid "memory allocation failed"
+msgstr ""
+
+#: ping/node_info.c:356
+#, c-format
+msgid "inappropriate subject name: %s"
+msgstr ""
+
+#: ping/node_info.c:359
+msgid "dn_comp() returned too long result"
+msgstr ""
+
+#: ping/node_info.c:399
+#, c-format
+msgid ""
+"ping -6 -N <nodeinfo opt>\n"
+"Help:\n"
+"  help\n"
+"Query:\n"
+"  name\n"
+"  ipv6\n"
+"  ipv6-all\n"
+"  ipv6-compatible\n"
+"  ipv6-global\n"
+"  ipv6-linklocal\n"
+"  ipv6-sitelocal\n"
+"  ipv4\n"
+"  ipv4-all\n"
+"Subject:\n"
+"  subject-ipv6=addr\n"
+"  subject-ipv4=addr\n"
+"  subject-name=name\n"
+"  subject-fqdn=name\n"
+msgstr ""
+
+#: ping/ping6_common.c:95 ping/ping.c:686 ping/ping.c:795
+#, c-format
+msgid "unknown iface: %s"
+msgstr ""
+
+#: ping/ping6_common.c:141
+msgid "scope discrepancy among the nodes"
+msgstr ""
+
+#: ping/ping6_common.c:214 ping/ping.c:751
+#, c-format
+msgid "Warning: source address might be selected on device other than: %s"
+msgstr ""
+
+#: ping/ping6_common.c:241
+#, c-format
+msgid "multicast ping with too short interval: %d"
+msgstr ""
+
+#: ping/ping6_common.c:244
+msgid "multicast ping does not fragment"
+msgstr ""
+
+#: ping/ping6_common.c:288
+msgid "setsockopt(RAW_CHECKSUM) failed - try to continue"
+msgstr ""
+
+#: ping/ping6_common.c:314
+msgid "can't disable multicast loopback"
+msgstr ""
+
+#: ping/ping6_common.c:319
+msgid "can't set multicast hop limit"
+msgstr ""
+
+#: ping/ping6_common.c:322
+msgid "can't set unicast hop limit"
+msgstr ""
+
+#: ping/ping6_common.c:334
+msgid "can't receive hop limit"
+msgstr ""
+
+#: ping/ping6_common.c:339
+msgid "setsockopt(IPV6_TCLASS)"
+msgstr ""
+
+#: ping/ping6_common.c:341
+msgid "traffic class is not supported"
+msgstr ""
+
+#: ping/ping6_common.c:357
+msgid "can't set flowlabel"
+msgstr ""
+
+#: ping/ping6_common.c:361
+msgid "can't send flowinfo"
+msgstr ""
+
+#: ping/ping6_common.c:364
+#, c-format
+msgid "PING %s(%s) "
+msgstr ""
+
+#: ping/ping6_common.c:366
+#, c-format
+msgid ", flow 0x%05x, "
+msgstr ""
+
+#: ping/ping6_common.c:371 ping/ping.c:924
+#, c-format
+msgid "from %s %s: "
+msgstr ""
+
+#: ping/ping6_common.c:374
+#, c-format
+msgid "%zu data bytes\n"
+msgstr ""
+
+#: ping/ping6_common.c:389
+#, c-format
+msgid "Destination unreachable: "
+msgstr ""
+
+#: ping/ping6_common.c:392
+#, c-format
+msgid "No route"
+msgstr ""
+
+#: ping/ping6_common.c:395
+#, c-format
+msgid "Administratively prohibited"
+msgstr ""
+
+#: ping/ping6_common.c:398
+#, c-format
+msgid "Beyond scope of source address"
+msgstr ""
+
+#: ping/ping6_common.c:401
+#, c-format
+msgid "Address unreachable"
+msgstr ""
+
+#: ping/ping6_common.c:404
+#, c-format
+msgid "Port unreachable"
+msgstr ""
+
+#: ping/ping6_common.c:407
+#, c-format
+msgid "Unknown code %d"
+msgstr ""
+
+#: ping/ping6_common.c:412
+#, c-format
+msgid "Packet too big: mtu=%u"
+msgstr ""
+
+#: ping/ping6_common.c:414
+#, c-format
+msgid ", code=%d"
+msgstr ""
+
+#: ping/ping6_common.c:417
+#, c-format
+msgid "Time exceeded: "
+msgstr ""
+
+#: ping/ping6_common.c:419
+#, c-format
+msgid "Hop limit"
+msgstr ""
+
+#: ping/ping6_common.c:421
+#, c-format
+msgid "Defragmentation failure"
+msgstr ""
+
+#: ping/ping6_common.c:423
+#, c-format
+msgid "code %d"
+msgstr ""
+
+#: ping/ping6_common.c:426
+#, c-format
+msgid "Parameter problem: "
+msgstr ""
+
+#: ping/ping6_common.c:428
+#, c-format
+msgid "Wrong header field "
+msgstr ""
+
+#: ping/ping6_common.c:430
+#, c-format
+msgid "Unknown header "
+msgstr ""
+
+#: ping/ping6_common.c:432
+#, c-format
+msgid "Unknown option "
+msgstr ""
+
+#: ping/ping6_common.c:434
+#, c-format
+msgid "code %d "
+msgstr ""
+
+#: ping/ping6_common.c:435
+#, c-format
+msgid "at %u"
+msgstr ""
+
+#: ping/ping6_common.c:438
+#, c-format
+msgid "Echo request"
+msgstr ""
+
+#: ping/ping6_common.c:441
+#, c-format
+msgid "Echo reply"
+msgstr ""
+
+#: ping/ping6_common.c:444
+#, c-format
+msgid "MLD Query"
+msgstr ""
+
+#: ping/ping6_common.c:447
+#, c-format
+msgid "MLD Report"
+msgstr ""
+
+#: ping/ping6_common.c:450
+#, c-format
+msgid "MLD Reduction"
+msgstr ""
+
+#: ping/ping6_common.c:453
+#, c-format
+msgid "unknown icmp type: %u"
+msgstr ""
+
+#: ping/ping6_common.c:504
+msgid "local error"
+msgstr ""
+
+#: ping/ping6_common.c:506
+#, c-format
+msgid "local error: message too long, mtu: %u"
+msgstr ""
+
+#: ping/ping6_common.c:528 ping/ping.c:1368
+#, c-format
+msgid "From %s icmp_seq=%u "
+msgstr ""
+
+#: ping/ping6_common.c:635 ping/ping.c:1482
+#, c-format
+msgid " icmp_seq=%u"
+msgstr ""
+
+#: ping/ping6_common.c:659 ping/ping6_common.c:720
+#, c-format
+msgid " parse error (too short)"
+msgstr ""
+
+#: ping/ping6_common.c:673 ping/ping6_common.c:729
+#, c-format
+msgid " parse error (truncated)"
+msgstr ""
+
+#: ping/ping6_common.c:733
+#, c-format
+msgid " unexpected error in inet_ntop(%s)"
+msgstr ""
+
+#: ping/ping6_common.c:742
+#, c-format
+msgid " (truncated)"
+msgstr ""
+
+#: ping/ping6_common.c:761
+#, c-format
+msgid " unknown qtype(0x%02x)"
+msgstr ""
+
+#: ping/ping6_common.c:765
+#, c-format
+msgid " refused"
+msgstr ""
+
+#: ping/ping6_common.c:768
+#, c-format
+msgid " unknown"
+msgstr ""
+
+#: ping/ping6_common.c:771
+#, c-format
+msgid " unknown code(%02x)"
+msgstr ""
+
+#: ping/ping6_common.c:773
+#, c-format
+msgid "; seq=%u;"
+msgstr ""
+
+#: ping/ping6_common.c:813
+#, c-format
+msgid "packet too short: %d bytes"
+msgstr ""
+
+#: ping/ping6_common.c:880 ping/ping.c:1611
+#, c-format
+msgid "From %s: "
+msgstr ""
+
+#: ping/ping6_common.c:921 ping/ping.c:1696
+msgid "WARNING: failed to install socket filter"
+msgstr ""
+
+#: ping/ping.c:186
+#, c-format
+msgid "option argument contains garbage: %s"
+msgstr ""
+
+#: ping/ping.c:187
+msgid "this will become fatal error in future"
+msgstr ""
+
+#: ping/ping.c:219
+#, c-format
+msgid "bad value for flowinfo: %s"
+msgstr ""
+
+#: ping/ping.c:222
+#, c-format
+msgid "flow value is greater than 20 bits: %s"
+msgstr ""
+
+#: ping/ping.c:242
+#, c-format
+msgid "bad TOS value: %s"
+msgstr ""
+
+#: ping/ping.c:245
+#, c-format
+msgid "the decimal value of TOS bits must be in range 0-255: %d"
+msgstr ""
+
+#: ping/ping.c:314 ping/ping.c:341
+msgid "only one -4 or -6 option may be specified"
+msgstr ""
+
+#: ping/ping.c:322 ping/ping.c:327
+msgid "only one of -T or -R may be used"
+msgstr ""
+
+#: ping/ping.c:336
+#, c-format
+msgid "invalid timestamp type: %s"
+msgstr ""
+
+#: ping/ping.c:376
+msgid "bad timing interval"
+msgstr ""
+
+#: ping/ping.c:378
+#, c-format
+msgid "bad timing interval: %s"
+msgstr ""
+
+#: ping/ping.c:389
+#, c-format
+msgid "cannot copy: %s"
+msgstr ""
+
+#: ping/ping.c:398
+#, c-format
+msgid "invalid source address: %s"
+msgstr ""
+
+#: ping/ping.c:412
+#, c-format
+msgid "cannot set preload to value greater than 3: %d"
+msgstr ""
+
+#: ping/ping.c:429
+#, c-format
+msgid "invalid -M argument: %s"
+msgstr ""
+
+#: ping/ping.c:485
+msgid "bad linger time"
+msgstr ""
+
+#: ping/ping.c:487
+#, c-format
+msgid "bad linger time: %s"
+msgstr ""
+
+#: ping/ping.c:576
+#, c-format
+msgid "unknown protocol family: %d"
+msgstr ""
+
+#: ping/ping.c:700
+msgid "warning: QOS sockopts"
+msgstr ""
+
+#: ping/ping.c:709
+msgid ""
+"Do you want to ping broadcast? Then -b. If not, check your local firewall "
+"rules"
+msgstr ""
+
+#: ping/ping.c:710
+#, c-format
+msgid "WARNING: pinging broadcast address\n"
+msgstr ""
+
+#: ping/ping.c:713 ping/ping.c:900
+msgid "cannot set broadcasting"
+msgstr ""
+
+#: ping/ping.c:733
+msgid "gatifaddrs failed"
+msgstr ""
+
+#: ping/ping.c:775
+msgid "unknown interface"
+msgstr ""
+
+#: ping/ping.c:802
+#, c-format
+msgid "broadcast ping with too short interval: %d"
+msgstr ""
+
+#: ping/ping.c:804
+msgid "broadcast ping does not fragment"
+msgstr ""
+
+#: ping/ping.c:828
+msgid "WARNING: setsockopt(ICMP_FILTER)"
+msgstr ""
+
+#: ping/ping.c:833
+msgid "WARNING: your kernel is veeery old. No problems."
+msgstr ""
+
+#: ping/ping.c:837
+msgid "WARNING: setsockopt(IP_RECVTTL)"
+msgstr ""
+
+#: ping/ping.c:839
+msgid "WARNING: setsockopt(IP_RETOPTS)"
+msgstr ""
+
+#: ping/ping.c:906
+msgid "cannot disable multicast loopback"
+msgstr ""
+
+#: ping/ping.c:911
+msgid "cannot set multicast time-to-live"
+msgstr ""
+
+#: ping/ping.c:913
+msgid "cannot set unicast time-to-live"
+msgstr ""
+
+#: ping/ping.c:922
+#, c-format
+msgid "PING %s (%s) "
+msgstr ""
+
+#: ping/ping.c:925
+#, c-format
+msgid "%zu(%zu) bytes of data.\n"
+msgstr ""
+
+#: ping/ping.c:951
+#, c-format
+msgid ""
+"\n"
+"NOP"
+msgstr ""
+
+#: ping/ping.c:962
+#, c-format
+msgid ""
+"\n"
+"%cSRR: "
+msgstr ""
+
+#: ping/ping.c:1000
+#, c-format
+msgid "\t(same route)"
+msgstr ""
+
+#: ping/ping.c:1005
+#, c-format
+msgid ""
+"\n"
+"RR: "
+msgstr ""
+
+#: ping/ping.c:1041
+#, c-format
+msgid ""
+"\n"
+"TS: "
+msgstr ""
+
+#: ping/ping.c:1073
+#, c-format
+msgid "\t%ld absolute not-standard"
+msgstr ""
+
+#: ping/ping.c:1075
+#, c-format
+msgid "\t%ld not-standard"
+msgstr ""
+
+#: ping/ping.c:1079
+#, c-format
+msgid "\t%ld absolute"
+msgstr ""
+
+#: ping/ping.c:1090
+#, c-format
+msgid "Unrecorded hops: %d\n"
+msgstr ""
+
+#: ping/ping.c:1094
+#, c-format
+msgid ""
+"\n"
+"unknown option %x"
+msgstr ""
+
+#: ping/ping.c:1114
+#, c-format
+msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
+msgstr ""
+
+#: ping/ping.c:1115
+#, c-format
+msgid " %1x  %1x  %02x %04x %04x"
+msgstr ""
+
+#: ping/ping.c:1117
+#, c-format
+msgid "   %1x %04x"
+msgstr ""
+
+#: ping/ping.c:1119
+#, c-format
+msgid "  %02x  %02x %04x"
+msgstr ""
+
+#: ping/ping.c:1135
+#, c-format
+msgid "Echo Reply\n"
+msgstr ""
+
+#: ping/ping.c:1141
+#, c-format
+msgid "Destination Net Unreachable\n"
+msgstr ""
+
+#: ping/ping.c:1144
+#, c-format
+msgid "Destination Host Unreachable\n"
+msgstr ""
+
+#: ping/ping.c:1147
+#, c-format
+msgid "Destination Protocol Unreachable\n"
+msgstr ""
+
+#: ping/ping.c:1150
+#, c-format
+msgid "Destination Port Unreachable\n"
+msgstr ""
+
+#: ping/ping.c:1153
+#, c-format
+msgid "Frag needed and DF set (mtu = %u)\n"
+msgstr ""
+
+#: ping/ping.c:1156
+#, c-format
+msgid "Source Route Failed\n"
+msgstr ""
+
+#: ping/ping.c:1159
+#, c-format
+msgid "Destination Net Unknown\n"
+msgstr ""
+
+#: ping/ping.c:1162
+#, c-format
+msgid "Destination Host Unknown\n"
+msgstr ""
+
+#: ping/ping.c:1165
+#, c-format
+msgid "Source Host Isolated\n"
+msgstr ""
+
+#: ping/ping.c:1168
+#, c-format
+msgid "Destination Net Prohibited\n"
+msgstr ""
+
+#: ping/ping.c:1171
+#, c-format
+msgid "Destination Host Prohibited\n"
+msgstr ""
+
+#: ping/ping.c:1174
+#, c-format
+msgid "Destination Net Unreachable for Type of Service\n"
+msgstr ""
+
+#: ping/ping.c:1177
+#, c-format
+msgid "Destination Host Unreachable for Type of Service\n"
+msgstr ""
+
+#: ping/ping.c:1180
+#, c-format
+msgid "Packet filtered\n"
+msgstr ""
+
+#: ping/ping.c:1183
+#, c-format
+msgid "Precedence Violation\n"
+msgstr ""
+
+#: ping/ping.c:1186
+#, c-format
+msgid "Precedence Cutoff\n"
+msgstr ""
+
+#: ping/ping.c:1189
+#, c-format
+msgid "Dest Unreachable, Bad Code: %d\n"
+msgstr ""
+
+#: ping/ping.c:1196
+#, c-format
+msgid "Source Quench\n"
+msgstr ""
+
+#: ping/ping.c:1203
+#, c-format
+msgid "Redirect Network"
+msgstr ""
+
+#: ping/ping.c:1206
+#, c-format
+msgid "Redirect Host"
+msgstr ""
+
+#: ping/ping.c:1209
+#, c-format
+msgid "Redirect Type of Service and Network"
+msgstr ""
+
+#: ping/ping.c:1212
+#, c-format
+msgid "Redirect Type of Service and Host"
+msgstr ""
+
+#: ping/ping.c:1215
+#, c-format
+msgid "Redirect, Bad Code: %d"
+msgstr ""
+
+#: ping/ping.c:1226
+#, c-format
+msgid "(New nexthop: %s)\n"
+msgstr ""
+
+#: ping/ping.c:1232
+#, c-format
+msgid "Echo Request\n"
+msgstr ""
+
+#: ping/ping.c:1238
+#, c-format
+msgid "Time to live exceeded\n"
+msgstr ""
+
+#: ping/ping.c:1241
+#, c-format
+msgid "Frag reassembly time exceeded\n"
+msgstr ""
+
+#: ping/ping.c:1244
+#, c-format
+msgid "Time exceeded, Bad Code: %d\n"
+msgstr ""
+
+#: ping/ping.c:1251
+#, c-format
+msgid "Parameter problem: pointer = %u\n"
+msgstr ""
+
+#: ping/ping.c:1257
+#, c-format
+msgid "Timestamp\n"
+msgstr ""
+
+#: ping/ping.c:1261
+#, c-format
+msgid "Timestamp Reply\n"
+msgstr ""
+
+#: ping/ping.c:1265
+#, c-format
+msgid "Information Request\n"
+msgstr ""
+
+#: ping/ping.c:1269
+#, c-format
+msgid "Information Reply\n"
+msgstr ""
+
+#: ping/ping.c:1274
+#, c-format
+msgid "Address Mask Request\n"
+msgstr ""
+
+#: ping/ping.c:1279
+#, c-format
+msgid "Address Mask Reply\n"
+msgstr ""
+
+#: ping/ping.c:1283
+#, c-format
+msgid "Bad ICMP type: %d\n"
+msgstr ""
+
+#: ping/ping.c:1332
+#, c-format
+msgid "local error: %s"
+msgstr ""
+
+#: ping/ping.c:1334
+#, c-format
+msgid "local error: message too long, mtu=%u"
+msgstr ""
+
+#: ping/ping.c:1506
+#, c-format
+msgid "packet too short (%d bytes) from %s"
+msgstr ""
+
+#: ping/ping.c:1586
+#, c-format
+msgid "From %s: icmp_seq=%u "
+msgstr ""
+
+#: ping/ping.c:1589
+#, c-format
+msgid "(BAD CHECKSUM)"
+msgstr ""
+
+#: ping/ping.c:1613
+#, c-format
+msgid "(BAD CHECKSUM)\n"
+msgstr ""
+
+#: ping/ping_common.c:208
+#, c-format
+msgid "patterns must be specified as hex digits: %s"
+msgstr ""
+
+#: ping/ping_common.c:225
+#, c-format
+msgid "PATTERN: 0x"
+msgstr ""
+
+#: ping/ping_common.c:345
+#, c-format
+msgid "no answer yet for icmp_seq=%lu\n"
+msgstr ""
+
+#: ping/ping_common.c:445
+msgid "WARNING: probably, rcvbuf is not enough to hold preload"
+msgstr ""
+
+#: ping/ping_common.c:461
+#, c-format
+msgid "cannot flood; minimal interval allowed for user is %dms"
+msgstr ""
+
+#: ping/ping_common.c:464
+#, c-format
+msgid "illegal preload and/or interval: %d"
+msgstr ""
+
+#: ping/ping_common.c:476
+msgid "Warning: no SO_TIMESTAMP support, falling back to SIOCGSTAMP"
+msgstr ""
+
+#: ping/ping_common.c:491
+#, c-format
+msgid "Warning: Failed to set mark: %d"
+msgstr ""
+
+#: ping/ping_common.c:750
+#, c-format
+msgid "Warning: time of day goes back (%ldus), taking countermeasures"
+msgstr ""
+
+#: ping/ping_common.c:800
+#, c-format
+msgid "%d bytes from %s:"
+msgstr ""
+
+#: ping/ping_common.c:806
+#, c-format
+msgid " ttl=%d"
+msgstr ""
+
+#: ping/ping_common.c:809
+#, c-format
+msgid " (truncated)\n"
+msgstr ""
+
+#: ping/ping_common.c:814
+#, c-format
+msgid " time=%ld ms"
+msgstr ""
+
+#: ping/ping_common.c:816
+#, c-format
+msgid " time=%ld.%01ld ms"
+msgstr ""
+
+#: ping/ping_common.c:819
+#, c-format
+msgid " time=%ld.%02ld ms"
+msgstr ""
+
+#: ping/ping_common.c:822
+#, c-format
+msgid " time=%ld.%03ld ms"
+msgstr ""
+
+#: ping/ping_common.c:826
+#, c-format
+msgid " (DUP!)"
+msgstr ""
+
+#: ping/ping_common.c:828
+#, c-format
+msgid " (BAD CHECKSUM!)"
+msgstr ""
+
+#: ping/ping_common.c:835
+#, c-format
+msgid ""
+"\n"
+"wrong data byte #%zu should be 0x%x but was 0x%x"
+msgstr ""
+
+#: ping/ping_common.c:878
+#, c-format
+msgid "--- %s ping statistics ---\n"
+msgstr ""
+
+#: ping/ping_common.c:879
+#, c-format
+msgid "%ld packets transmitted, "
+msgstr ""
+
+#: ping/ping_common.c:880
+#, c-format
+msgid "%ld received"
+msgstr ""
+
+#: ping/ping_common.c:882
+#, c-format
+msgid ", +%ld duplicates"
+msgstr ""
+
+#: ping/ping_common.c:884
+#, c-format
+msgid ", +%ld corrupted"
+msgstr ""
+
+#: ping/ping_common.c:886
+#, c-format
+msgid ", +%ld errors"
+msgstr ""
+
+#: ping/ping_common.c:892
+#, c-format
+msgid ", %g%% packet loss"
+msgstr ""
+
+#: ping/ping_common.c:894
+#, c-format
+msgid ", time %ldms"
+msgstr ""
+
+#: ping/ping_common.c:914
+#, c-format
+msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
+msgstr ""
+
+#: ping/ping_common.c:922
+#, c-format
+msgid "%spipe %d"
+msgstr ""
+
+#: ping/ping_common.c:929
+#, c-format
+msgid "%sipg/ewma %d.%03d/%d.%03d ms"
+msgstr ""
+
+#: ping/ping_common.c:947
+#, c-format
+msgid "%ld/%ld packets, %d%% loss"
+msgstr ""
+
+#: ping/ping_common.c:952
+#, c-format
+msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
+msgstr ""
+
+#: tracepath.c:215
+#, c-format
+msgid ""
+"cmsg6:%d\n"
+" "
+msgstr ""
+
+#: tracepath.c:227
+#, c-format
+msgid ""
+"cmsg4:%d\n"
+" "
+msgstr ""
+
+#: tracepath.c:232
+#, c-format
+msgid "no info\n"
+msgstr ""
+
+#: tracepath.c:236
+msgid "[LOCALHOST]"
+msgstr ""
+
+#: tracepath.c:284
+#, c-format
+msgid "%3ld.%03ldms "
+msgstr ""
+
+#: tracepath.c:287
+#, c-format
+msgid "(This broken router returned corrupted payload) "
+msgstr ""
+
+#: tracepath.c:302
+#, c-format
+msgid "pmtu %d\n"
+msgstr ""
+
+#: tracepath.c:307
+#, c-format
+msgid "reached\n"
+msgstr ""
+
+#: tracepath.c:323 tracepath.c:326
+#, c-format
+msgid "asymm %2d "
+msgstr ""
+
+#: tracepath.c:341
+msgid "NET ERROR"
+msgstr ""
+
+#: tracepath.c:386
+#, c-format
+msgid "%2d?: reply received 8)\n"
+msgstr ""
+
+#: tracepath.c:392
+#, c-format
+msgid "%2d:  send failed\n"
+msgstr ""
+
+#: tracepath.c:399
+#, c-format
+msgid ""
+"\n"
+"Usage\n"
+"  tracepath [options] <destination>\n"
+"\n"
+"Options:\n"
+"  -4             use IPv4\n"
+"  -6             use IPv6\n"
+"  -b             print both name and ip\n"
+"  -l <length>    use packet <length>\n"
+"  -m <hops>      use maximum <hops>\n"
+"  -n             no dns name resolution\n"
+"  -p <port>      use destination <port>\n"
+"  -V             print version and exit\n"
+"  <destination>  dns name or ip address\n"
+"\n"
+"For more details see tracepath(8).\n"
+msgstr ""
+
+#: tracepath.c:457 tracepath.c:462
+msgid "Only one -4 or -6 option may be specified"
+msgstr ""
+
+#: tracepath.c:603
+#, c-format
+msgid "%2d:  no reply\n"
+msgstr ""
+
+#: tracepath.c:610
+#, c-format
+msgid "     Resume: pmtu %d "
+msgstr ""
+
+#: tracepath.c:612
+#, c-format
+msgid "hops %d "
+msgstr ""
+
+#: tracepath.c:614
+#, c-format
+msgid "back %d "
+msgstr ""
+
+#: tracepath.c:619
+#, c-format
+msgid "pktlen must be within: %d < value <= %d"
+msgstr ""
+
+#: traceroute6.c:437
+#, c-format
+msgid "traceroute: wrote %s %d chars, ret=%d\n"
+msgstr ""
+
+#: traceroute6.c:466
+msgid "Error"
+msgstr ""
+
+#: traceroute6.c:468
+msgid "Destination Unreachable"
+msgstr ""
+
+#: traceroute6.c:470
+msgid "Packet Too Big"
+msgstr ""
+
+#: traceroute6.c:472
+msgid "Time Exceeded in Transit"
+msgstr ""
+
+#: traceroute6.c:474
+msgid "Parameter Problem"
+msgstr ""
+
+#: traceroute6.c:476
+msgid "Echo Request"
+msgstr ""
+
+#: traceroute6.c:478
+msgid "Echo Reply"
+msgstr ""
+
+#: traceroute6.c:480
+msgid "Membership Query"
+msgstr ""
+
+#: traceroute6.c:482
+msgid "Membership Report"
+msgstr ""
+
+#: traceroute6.c:484
+msgid "Membership Reduction"
+msgstr ""
+
+#: traceroute6.c:486
+msgid "Router Solicitation"
+msgstr ""
+
+#: traceroute6.c:488
+msgid "Router Advertisement"
+msgstr ""
+
+#: traceroute6.c:490
+msgid "Neighbor Solicitation"
+msgstr ""
+
+#: traceroute6.c:492
+msgid "Neighbor Advertisement"
+msgstr ""
+
+#: traceroute6.c:494
+msgid "Redirect"
+msgstr ""
+
+#: traceroute6.c:496
+msgid "Neighbor Query"
+msgstr ""
+
+#: traceroute6.c:498
+msgid "Neighbor Reply"
+msgstr ""
+
+#: traceroute6.c:500
+msgid "Multicast Listener Report packet"
+msgstr ""
+
+#: traceroute6.c:502
+msgid "Home Agent Address Discovery Request Message"
+msgstr ""
+
+#: traceroute6.c:504
+msgid "Home Agent Address Discovery Reply message"
+msgstr ""
+
+#: traceroute6.c:506
+msgid "Mobile Prefix Solicitation Message"
+msgstr ""
+
+#: traceroute6.c:508
+msgid "Mobile Prefix Solicitation Advertisement"
+msgstr ""
+
+#: traceroute6.c:510
+msgid "OUT-OF-RANGE"
 msgstr ""
 
 #: traceroute6.c:600
@@ -160,1270 +1412,13 @@ msgid ""
 "For more details see traceroute6(8).\n"
 msgstr ""
 
-#: clockdiff.c:618
-#, c-format
-msgid ""
-"\n"
-"host=%s rtt=%ld(%ld)ms/%ldms delta=%dms/%dms %s"
+#: traceroute6.c:718
+msgid "wait must be >1 sec"
 msgstr ""
 
-#: ping/ping.c:1096
-#, c-format
-msgid ""
-"\n"
-"unknown option %x"
-msgstr ""
-
-#: ping/ping_common.c:835
-#, c-format
-msgid ""
-"\n"
-"wrong data byte #%zu should be 0x%x but was 0x%x"
-msgstr ""
-
-#: tracepath.c:609
-#, c-format
-msgid "     Resume: pmtu %d "
-msgstr ""
-
-#: ping/ping.c:1119
-#, c-format
-msgid "   %1x %04x"
-msgstr ""
-
-#: traceroute6.c:875
-#, c-format
-msgid "  %.4f ms"
-msgstr ""
-
-#: ping/ping.c:1121
-#, c-format
-msgid "  %02x  %02x %04x"
-msgstr ""
-
-#: ping/ping.c:1117
-#, c-format
-msgid " %1x  %1x  %02x %04x %04x"
-msgstr ""
-
-#: arping.c:408
-#, c-format
-msgid " %ld.%03ldms\n"
-msgstr ""
-
-#: ping/ping_common.c:828
-#, c-format
-msgid " (BAD CHECKSUM!)"
-msgstr ""
-
-#: ping/ping_common.c:826
-#, c-format
-msgid " (DUP!)"
-msgstr ""
-
-#: ping/ping6_common.c:742
-#, c-format
-msgid " (truncated)"
-msgstr ""
-
-#: ping/ping_common.c:809
-#, c-format
-msgid " (truncated)\n"
-msgstr ""
-
-#: arping.c:410
-#, c-format
-msgid " UNSOLICITED?\n"
-msgstr ""
-
-#: traceroute6.c:848
-#, c-format
-msgid " from %s"
-msgstr ""
-
-#: ping/ping6_common.c:635 ping/ping.c:1484
-#, c-format
-msgid " icmp_seq=%u"
-msgstr ""
-
-#: ping/ping6_common.c:659 ping/ping6_common.c:720
-#, c-format
-msgid " parse error (too short)"
-msgstr ""
-
-#: ping/ping6_common.c:673 ping/ping6_common.c:729
-#, c-format
-msgid " parse error (truncated)"
-msgstr ""
-
-#: ping/ping6_common.c:765
-#, c-format
-msgid " refused"
-msgstr ""
-
-#: ping/ping_common.c:814
-#, c-format
-msgid " time=%ld ms"
-msgstr ""
-
-#: ping/ping_common.c:816
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr ""
-
-#: ping/ping_common.c:819
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr ""
-
-#: ping/ping_common.c:822
-#, c-format
-msgid " time=%ld.%03ld ms"
-msgstr ""
-
-#: ping/ping_common.c:806
-#, c-format
-msgid " ttl=%d"
-msgstr ""
-
-#: ping/ping6_common.c:733
-#, c-format
-msgid " unexpected error in inet_ntop(%s)"
-msgstr ""
-
-#: ping/ping6_common.c:768
-#, c-format
-msgid " unknown"
-msgstr ""
-
-#: ping/ping6_common.c:771
-#, c-format
-msgid " unknown code(%02x)"
-msgstr ""
-
-#: ping/ping6_common.c:761
-#, c-format
-msgid " unknown qtype(0x%02x)"
-msgstr ""
-
-#: tracepath.c:602
-#, c-format
-msgid "%2d:  no reply\n"
-msgstr ""
-
-#: tracepath.c:391
-#, c-format
-msgid "%2d:  send failed\n"
-msgstr ""
-
-#: tracepath.c:385
-#, c-format
-msgid "%2d?: reply received 8)\n"
-msgstr ""
-
-#: tracepath.c:284
-#, c-format
-msgid "%3ld.%03ldms "
-msgstr ""
-
-#: ping/ping_common.c:800
-#, c-format
-msgid "%d bytes from %s:"
-msgstr ""
-
-#: arping.c:290
-#, c-format
-msgid "%d request(s)"
-msgstr ""
-
-#: ping/ping_common.c:879
-#, c-format
-msgid "%ld packets transmitted, "
-msgstr ""
-
-#: ping/ping_common.c:880
-#, c-format
-msgid "%ld received"
-msgstr ""
-
-#: ping/ping_common.c:947
-#, c-format
-msgid "%ld/%ld packets, %d%% loss"
-msgstr ""
-
-#: arping.c:388
-#, c-format
-msgid "%s from "
-msgstr ""
-
-#: clockdiff.c:594
-#, c-format
-msgid "%s is down"
-msgstr ""
-
-#: clockdiff.c:600
-#, c-format
-msgid "%s is unreachable"
-msgstr ""
-
-#: clockdiff.c:597
-#, c-format
-msgid "%s time transmitted in a non-standard format"
-msgstr ""
-
-#: arping.c:292
-#, c-format
-msgid "%s%d broadcast(s)"
-msgstr ""
-
-#: ping/ping_common.c:929
-#, c-format
-msgid "%sipg/ewma %d.%03d/%d.%03d ms"
-msgstr ""
-
-#: ping/ping_common.c:922
-#, c-format
-msgid "%spipe %d"
-msgstr ""
-
-#: ping/ping6_common.c:374
-#, c-format
-msgid "%zu data bytes\n"
-msgstr ""
-
-#: ping/ping.c:927
-#, c-format
-msgid "%zu(%zu) bytes of data.\n"
-msgstr ""
-
-#: ping/ping.c:1588
-#, c-format
-msgid "(BAD CHECKSUM)"
-msgstr ""
-
-#: ping/ping.c:1612
-#, c-format
-msgid "(BAD CHECKSUM)\n"
-msgstr ""
-
-#: ping/ping.c:1228
-#, c-format
-msgid "(New nexthop: %s)\n"
-msgstr ""
-
-#: tracepath.c:287
-#, c-format
-msgid "(This broken router returned corrupted payload) "
-msgstr ""
-
-#: traceroute6.c:849
-#, c-format
-msgid ", %d hops max, %d byte packets\n"
-msgstr ""
-
-#: ping/ping_common.c:892
-#, c-format
-msgid ", %g%% packet loss"
-msgstr ""
-
-#: ping/ping_common.c:884
-#, c-format
-msgid ", +%ld corrupted"
-msgstr ""
-
-#: ping/ping_common.c:882
-#, c-format
-msgid ", +%ld duplicates"
-msgstr ""
-
-#: ping/ping_common.c:886
-#, c-format
-msgid ", +%ld errors"
-msgstr ""
-
-#: ping/ping6_common.c:414
-#, c-format
-msgid ", code=%d"
-msgstr ""
-
-#: ping/ping6_common.c:366
-#, c-format
-msgid ", flow 0x%05x, "
-msgstr ""
-
-#: ping/ping_common.c:952
-#, c-format
-msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
-msgstr ""
-
-#: ping/ping_common.c:894
-#, c-format
-msgid ", time %ldms"
-msgstr ""
-
-#: ping/ping_common.c:878
-#, c-format
-msgid "--- %s ping statistics ---\n"
-msgstr ""
-
-#: ping/ping6_common.c:773
-#, c-format
-msgid "; seq=%u;"
-msgstr ""
-
-#: arping.c:1015
-#, c-format
-msgid "ARPING %s "
-msgstr ""
-
-#: ping/ping.c:1281
-#, c-format
-msgid "Address Mask Reply\n"
-msgstr ""
-
-#: ping/ping.c:1276
-#, c-format
-msgid "Address Mask Request\n"
-msgstr ""
-
-#: ping/ping6_common.c:401
-#, c-format
-msgid "Address unreachable"
-msgstr ""
-
-#: ping/ping6_common.c:395
-#, c-format
-msgid "Administratively prohibited"
-msgstr ""
-
-#: ping/ping.c:1285
-#, c-format
-msgid "Bad ICMP type: %d\n"
-msgstr ""
-
-#: ping/ping6_common.c:398
-#, c-format
-msgid "Beyond scope of source address"
-msgstr ""
-
-#: arping.c:387
-msgid "Broadcast"
-msgstr ""
-
-#: ping/ping6_common.c:421
-#, c-format
-msgid "Defragmentation failure"
-msgstr ""
-
-#: ping/ping.c:1191
-#, c-format
-msgid "Dest Unreachable, Bad Code: %d\n"
-msgstr ""
-
-#: ping/ping.c:1173
-#, c-format
-msgid "Destination Host Prohibited\n"
-msgstr ""
-
-#: ping/ping.c:1164
-#, c-format
-msgid "Destination Host Unknown\n"
-msgstr ""
-
-#: ping/ping.c:1146
-#, c-format
-msgid "Destination Host Unreachable\n"
-msgstr ""
-
-#: ping/ping.c:1179
-#, c-format
-msgid "Destination Host Unreachable for Type of Service\n"
-msgstr ""
-
-#: ping/ping.c:1170
-#, c-format
-msgid "Destination Net Prohibited\n"
-msgstr ""
-
-#: ping/ping.c:1161
-#, c-format
-msgid "Destination Net Unknown\n"
-msgstr ""
-
-#: ping/ping.c:1143
-#, c-format
-msgid "Destination Net Unreachable\n"
-msgstr ""
-
-#: ping/ping.c:1176
-#, c-format
-msgid "Destination Net Unreachable for Type of Service\n"
-msgstr ""
-
-#: ping/ping.c:1152
-#, c-format
-msgid "Destination Port Unreachable\n"
-msgstr ""
-
-#: ping/ping.c:1149
-#, c-format
-msgid "Destination Protocol Unreachable\n"
-msgstr ""
-
-#: traceroute6.c:468
-msgid "Destination Unreachable"
-msgstr ""
-
-#: ping/ping6_common.c:389
-#, c-format
-msgid "Destination unreachable: "
-msgstr ""
-
-#: arping.c:944
-#, c-format
-msgid "Device %s not available."
-msgstr ""
-
-#: ping/ping.c:711
-msgid ""
-"Do you want to ping broadcast? Then -b. If not, check your local firewall "
-"rules"
-msgstr ""
-
-#: traceroute6.c:478
-msgid "Echo Reply"
-msgstr ""
-
-#: ping/ping.c:1137
-#, c-format
-msgid "Echo Reply\n"
-msgstr ""
-
-#: traceroute6.c:476
-msgid "Echo Request"
-msgstr ""
-
-#: ping/ping.c:1234
-#, c-format
-msgid "Echo Request\n"
-msgstr ""
-
-#: ping/ping6_common.c:441
-#, c-format
-msgid "Echo reply"
-msgstr ""
-
-#: ping/ping6_common.c:438
-#, c-format
-msgid "Echo request"
-msgstr ""
-
-#: traceroute6.c:466
-msgid "Error"
-msgstr ""
-
-#: ping/ping.c:1155
-#, c-format
-msgid "Frag needed and DF set (mtu = %u)\n"
-msgstr ""
-
-#: ping/ping.c:1243
-#, c-format
-msgid "Frag reassembly time exceeded\n"
-msgstr ""
-
-#: ping/ping6_common.c:528 ping/ping.c:1370
-#, c-format
-msgid "From %s icmp_seq=%u "
-msgstr ""
-
-#: ping/ping6_common.c:876 ping/ping.c:1610
-#, c-format
-msgid "From %s: "
-msgstr ""
-
-#: ping/ping.c:1585
-#, c-format
-msgid "From %s: icmp_seq=%u "
-msgstr ""
-
-#: traceroute6.c:504
-msgid "Home Agent Address Discovery Reply message"
-msgstr ""
-
-#: traceroute6.c:502
-msgid "Home Agent Address Discovery Request Message"
-msgstr ""
-
-#: ping/ping6_common.c:419
-#, c-format
-msgid "Hop limit"
-msgstr ""
-
-#: ping/node_info.c:308
-#, c-format
-msgid "IDN encoding error: %s"
-msgstr ""
-
-#: ping/ping.c:1271
-#, c-format
-msgid "Information Reply\n"
-msgstr ""
-
-#: ping/ping.c:1267
-#, c-format
-msgid "Information Request\n"
-msgstr ""
-
-#: arping.c:561
-#, c-format
-msgid "Interface \"%s\" is down\n"
-msgstr ""
-
-#: arping.c:569
-#, c-format
-msgid "Interface \"%s\" is not ARPable\n"
-msgstr ""
-
-#: arping.c:1006
-#, c-format
-msgid "Interface \"%s\" is not ARPable (no ll address)\n"
-msgstr ""
-
-#: ping/ping6_common.c:444
-#, c-format
-msgid "MLD Query"
-msgstr ""
-
-#: ping/ping6_common.c:450
-#, c-format
-msgid "MLD Reduction"
-msgstr ""
-
-#: ping/ping6_common.c:447
-#, c-format
-msgid "MLD Report"
-msgstr ""
-
-#: traceroute6.c:480
-msgid "Membership Query"
-msgstr ""
-
-#: traceroute6.c:484
-msgid "Membership Reduction"
-msgstr ""
-
-#: traceroute6.c:482
-msgid "Membership Report"
-msgstr ""
-
-#: traceroute6.c:508
-msgid "Mobile Prefix Solicitation Advertisement"
-msgstr ""
-
-#: traceroute6.c:506
-msgid "Mobile Prefix Solicitation Message"
-msgstr ""
-
-#: traceroute6.c:500
-msgid "Multicast Listener Report packet"
-msgstr ""
-
-#: tracepath.c:340
-msgid "NET ERROR"
-msgstr ""
-
-#: traceroute6.c:492
-msgid "Neighbor Advertisement"
-msgstr ""
-
-#: traceroute6.c:496
-msgid "Neighbor Query"
-msgstr ""
-
-#: traceroute6.c:498
-msgid "Neighbor Reply"
-msgstr ""
-
-#: traceroute6.c:490
-msgid "Neighbor Solicitation"
-msgstr ""
-
-#: ping/ping6_common.c:392
-#, c-format
-msgid "No route"
-msgstr ""
-
-#: traceroute6.c:510
-msgid "OUT-OF-RANGE"
-msgstr ""
-
-#: tracepath.c:456 tracepath.c:461
-msgid "Only one -4 or -6 option may be specified"
-msgstr ""
-
-#: clockdiff.c:245
-#, c-format
-msgid "Overflow %d hops\n"
-msgstr ""
-
-#: ping/ping_common.c:225
-#, c-format
-msgid "PATTERN: 0x"
-msgstr ""
-
-#: ping/ping.c:924
-#, c-format
-msgid "PING %s (%s) "
-msgstr ""
-
-#: ping/ping6_common.c:364
-#, c-format
-msgid "PING %s(%s) "
-msgstr ""
-
-#: traceroute6.c:470
-msgid "Packet Too Big"
-msgstr ""
-
-#: ping/ping.c:1182
-#, c-format
-msgid "Packet filtered\n"
-msgstr ""
-
-#: ping/ping6_common.c:412
-#, c-format
-msgid "Packet too big: mtu=%u"
-msgstr ""
-
-#: traceroute6.c:474
-msgid "Parameter Problem"
-msgstr ""
-
-#: ping/ping6_common.c:426
-#, c-format
-msgid "Parameter problem: "
-msgstr ""
-
-#: ping/ping.c:1253
-#, c-format
-msgid "Parameter problem: pointer = %u\n"
-msgstr ""
-
-#: ping/ping6_common.c:404
-#, c-format
-msgid "Port unreachable"
-msgstr ""
-
-#: ping/ping.c:1188
-#, c-format
-msgid "Precedence Cutoff\n"
-msgstr ""
-
-#: ping/ping.c:1185
-#, c-format
-msgid "Precedence Violation\n"
-msgstr ""
-
-#: ping/node_info.c:165
-#, c-format
-msgid "Qtype conflict\n"
-msgstr ""
-
-#: arping.c:286
-#, c-format
-msgid "Received %d response(s)"
-msgstr ""
-
-#: traceroute6.c:494
-msgid "Redirect"
-msgstr ""
-
-#: ping/ping.c:1208
-#, c-format
-msgid "Redirect Host"
-msgstr ""
-
-#: ping/ping.c:1205
-#, c-format
-msgid "Redirect Network"
-msgstr ""
-
-#: ping/ping.c:1214
-#, c-format
-msgid "Redirect Type of Service and Host"
-msgstr ""
-
-#: ping/ping.c:1211
-#, c-format
-msgid "Redirect Type of Service and Network"
-msgstr ""
-
-#: ping/ping.c:1217
-#, c-format
-msgid "Redirect, Bad Code: %d"
-msgstr ""
-
-#: traceroute6.c:488
-msgid "Router Advertisement"
-msgstr ""
-
-#: traceroute6.c:486
-msgid "Router Solicitation"
-msgstr ""
-
-#: arping.c:285
-#, c-format
-msgid "Sent %d probes (%d broadcast(s))\n"
-msgstr ""
-
-#: ping/ping.c:1167
-#, c-format
-msgid "Source Host Isolated\n"
-msgstr ""
-
-#: ping/ping.c:1198
-#, c-format
-msgid "Source Quench\n"
-msgstr ""
-
-#: ping/ping.c:1158
-#, c-format
-msgid "Source Route Failed\n"
-msgstr ""
-
-#: ping/node_info.c:217
-#, c-format
-msgid "Subject type conflict\n"
-msgstr ""
-
-#: arping.c:945
-msgid "Suitable device could not be determined. Please, use option -I."
-msgstr ""
-
-#: traceroute6.c:472
-msgid "Time Exceeded in Transit"
-msgstr ""
-
-#: ping/ping.c:1246
-#, c-format
-msgid "Time exceeded, Bad Code: %d\n"
-msgstr ""
-
-#: ping/ping6_common.c:417
-#, c-format
-msgid "Time exceeded: "
-msgstr ""
-
-#: ping/ping.c:1240
-#, c-format
-msgid "Time to live exceeded\n"
-msgstr ""
-
-#: ping/ping.c:1259
-#, c-format
-msgid "Timestamp\n"
-msgstr ""
-
-#: ping/ping.c:1263
-#, c-format
-msgid "Timestamp Reply\n"
-msgstr ""
-
-#: arping.c:387
-msgid "Unicast"
-msgstr ""
-
-#: ping/ping6_common.c:407
-#, c-format
-msgid "Unknown code %d"
-msgstr ""
-
-#: ping/ping6_common.c:430
-#, c-format
-msgid "Unknown header "
-msgstr ""
-
-#: ping/ping6_common.c:432
-#, c-format
-msgid "Unknown option "
-msgstr ""
-
-#: ping/ping.c:1092
-#, c-format
-msgid "Unrecorded hops: %d\n"
-msgstr ""
-
-#. point to options
-#: ping/ping.c:1116
-#, c-format
-msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
-msgstr ""
-
-#: ping/ping6_common.c:918 ping/ping.c:1695
-msgid "WARNING: failed to install socket filter"
-msgstr ""
-
-#: traceroute6.c:822 arping.c:965
-msgid "WARNING: interface is ignored"
-msgstr ""
-
-#: ping/ping.c:712
-#, c-format
-msgid "WARNING: pinging broadcast address\n"
-msgstr ""
-
-#: ping/ping_common.c:445
-msgid "WARNING: probably, rcvbuf is not enough to hold preload"
-msgstr ""
-
-#: ping/ping.c:830
-msgid "WARNING: setsockopt(ICMP_FILTER)"
-msgstr ""
-
-#: ping/ping.c:839
-msgid "WARNING: setsockopt(IP_RECVTTL)"
-msgstr ""
-
-#: ping/ping.c:841
-msgid "WARNING: setsockopt(IP_RETOPTS)"
-msgstr ""
-
-#: arping.c:983
-msgid "WARNING: setsockopt(SO_DONTROUTE)"
-msgstr ""
-
-#: arping.c:662
-#, c-format
-msgid "WARNING: using default broadcast address.\n"
-msgstr ""
-
-#: ping/ping.c:835
-msgid "WARNING: your kernel is veeery old. No problems."
-msgstr ""
-
-#. Do not exit, old kernels do not support mark.
-#: ping/ping_common.c:491
-#, c-format
-msgid "Warning: Failed to set mark: %d"
-msgstr ""
-
-#: ping/ping_common.c:476
-msgid "Warning: no SO_TIMESTAMP support, falling back to SIOCGSTAMP"
-msgstr ""
-
-#: ping/ping6_common.c:206 ping/ping.c:753
-#, c-format
-msgid "Warning: source address might be selected on device other than: %s"
-msgstr ""
-
-#: ping/ping_common.c:750
-#, c-format
-msgid "Warning: time of day goes back (%ldus), taking countermeasures"
-msgstr ""
-
-#: ping/ping6_common.c:428
-#, c-format
-msgid "Wrong header field "
-msgstr ""
-
-#: clockdiff.c:240
-#, c-format
-msgid "Wrong timestamp %d\n"
-msgstr ""
-
-#: tracepath.c:236
-msgid "[LOCALHOST]"
-msgstr ""
-
-#: tracepath.c:323 tracepath.c:325
-#, c-format
-msgid "asymm %2d "
-msgstr ""
-
-#: ping/ping6_common.c:435
-#, c-format
-msgid "at %u"
-msgstr ""
-
-#: tracepath.c:613
-#, c-format
-msgid "back %d "
-msgstr ""
-
-#: ping/ping.c:244
-#, c-format
-msgid "bad TOS value: %s"
-msgstr ""
-
-#: ping/ping.c:487
-msgid "bad linger time"
-msgstr ""
-
-#: ping/ping.c:489
-#, c-format
-msgid "bad linger time: %s"
-msgstr ""
-
-#: ping/ping.c:378
-msgid "bad timing interval"
-msgstr ""
-
-#: ping/ping.c:380
-#, c-format
-msgid "bad timing interval: %s"
-msgstr ""
-
-#: ping/ping.c:221
-#, c-format
-msgid "bad value for flowinfo: %s"
-msgstr ""
-
-#: ping/ping.c:806
-msgid "broadcast ping does not fragment"
-msgstr ""
-
-#: ping/ping.c:804
-#, c-format
-msgid "broadcast ping with too short interval: %d"
-msgstr ""
-
-#: ping/ping6_common.c:306
-msgid "can't disable multicast loopback"
-msgstr ""
-
-#: ping/ping6_common.c:326
-msgid "can't receive hop limit"
-msgstr ""
-
-#: ping/ping6_common.c:358
-msgid "can't send flowinfo"
-msgstr ""
-
-#: ping/ping6_common.c:349
-msgid "can't set flowlabel"
-msgstr ""
-
-#: ping/ping6_common.c:311
-msgid "can't set multicast hop limit"
-msgstr ""
-
-#: ping/ping6_common.c:314
-msgid "can't set unicast hop limit"
-msgstr ""
-
-#: ping/ping.c:391
-#, c-format
-msgid "cannot copy: %s"
-msgstr ""
-
-#: ping/ping.c:908
-msgid "cannot disable multicast loopback"
-msgstr ""
-
-#: ping/ping_common.c:461
-#, c-format
-msgid "cannot flood; minimal interval allowed for user is %dms"
-msgstr ""
-
-#: ping/ping.c:715 ping/ping.c:902
-msgid "cannot set broadcasting"
-msgstr ""
-
-#: ping/ping.c:913
-msgid "cannot set multicast time-to-live"
-msgstr ""
-
-#: ping/ping.c:414
-#, c-format
-msgid "cannot set preload to value greater than 3: %d"
-msgstr ""
-
-#: ping/ping.c:915
-msgid "cannot set unicast time-to-live"
-msgstr ""
-
-#: tracepath.c:227
-#, c-format
-msgid ""
-"cmsg4:%d\n"
-" "
-msgstr ""
-
-#: tracepath.c:215
-#, c-format
-msgid ""
-"cmsg6:%d\n"
-" "
-msgstr ""
-
-#: ping/ping6_common.c:423
-#, c-format
-msgid "code %d"
-msgstr ""
-
-#: ping/ping6_common.c:434
-#, c-format
-msgid "code %d "
-msgstr ""
-
-#: ping/node_info.c:358
-msgid "dn_comp() returned too long result"
-msgstr ""
-
-#: ping/ping6_common.c:352
-msgid "flow labels are not supported"
-msgstr ""
-
-#: ping/ping.c:224
-#, c-format
-msgid "flow value is greater than 20 bits: %s"
-msgstr ""
-
-#: ping/ping6_common.c:360
-msgid "flowinfo is not supported"
-msgstr ""
-
-#: arping.c:398
-#, c-format
-msgid "for "
-msgstr ""
-
-#: arping.c:393
-#, c-format
-msgid "for %s "
-msgstr ""
-
-#: arping.c:1016
-#, c-format
-msgid "from %s %s\n"
-msgstr ""
-
-#: ping/ping6_common.c:371 ping/ping.c:926
-#, c-format
-msgid "from %s %s: "
-msgstr ""
-
-#: ping/ping.c:735
-msgid "gatifaddrs failed"
-msgstr ""
-
-#: tracepath.c:611
-#, c-format
-msgid "hops %d "
-msgstr ""
-
-#: ping/ping_common.c:464
-#, c-format
-msgid "illegal preload and/or interval: %d"
-msgstr ""
-
-#: ping/node_info.c:355
-#, c-format
-msgid "inappropriate subject name: %s"
-msgstr ""
-
-#: ping/ping.c:431
-#, c-format
-msgid "invalid -M argument: %s"
-msgstr ""
-
-#: traceroute6.c:688 traceroute6.c:694 traceroute6.c:697 ping/ping.c:366
-#: ping/ping.c:412 ping/ping.c:420 ping/ping.c:462 ping/ping.c:465
-#: ping/ping.c:468 ping/ping.c:481 tracepath.c:471 tracepath.c:474
-#: tracepath.c:477 tracepath.c:498 arping.c:872 arping.c:875 arping.c:878
-msgid "invalid argument"
-msgstr ""
-
-#: ping/ping.c:400
-#, c-format
-msgid "invalid source address: %s"
-msgstr ""
-
-#: ping/ping.c:338
-#, c-format
-msgid "invalid timestamp type: %s"
-msgstr ""
-
-#: ping/ping6_common.c:504
-msgid "local error"
-msgstr ""
-
-#: ping/ping.c:1334
-#, c-format
-msgid "local error: %s"
-msgstr ""
-
-#: ping/ping6_common.c:506
-#, c-format
-msgid "local error: message too long, mtu: %u"
-msgstr ""
-
-#: ping/ping.c:1336
-#, c-format
-msgid "local error: message too long, mtu=%u"
-msgstr ""
-
-#: clockdiff.c:589
-msgid "measure: unknown failure"
-msgstr ""
-
-#: ping/ping6_common.c:258 ping/node_info.c:343 ping/node_info.c:385
-#: ping/ping.c:449 ping/ping.c:512 ping/ping.c:922
-msgid "memory allocation failed"
-msgstr ""
-
-#: ping/ping6_common.c:236
-msgid "multicast ping does not fragment"
-msgstr ""
-
-#: ping/ping6_common.c:233
-#, c-format
-msgid "multicast ping with too short interval: %d"
-msgstr ""
-
-#: ping/ping_common.c:345
-#, c-format
-msgid "no answer yet for icmp_seq=%lu\n"
-msgstr ""
-
-#: tracepath.c:232
-#, c-format
-msgid "no info\n"
-msgstr ""
-
-#: arping.c:1020
-msgid "no source address in not-DAD mode"
-msgstr ""
-
-#: ping/ping.c:316 ping/ping.c:343
-msgid "only one -4 or -6 option may be specified"
-msgstr ""
-
-#: ping/ping.c:324 ping/ping.c:329
-msgid "only one of -T or -R may be used"
-msgstr ""
-
-#: ping/ping.c:188
-#, c-format
-msgid "option argument contains garbage: %s"
-msgstr ""
-
-#: ping/ping.c:1508
-#, c-format
-msgid "packet too short (%d bytes) from %s"
-msgstr ""
-
-#: ping/ping6_common.c:813
-#, c-format
-msgid "packet too short: %d bytes"
-msgstr ""
-
-#: ping/ping_common.c:208
-#, c-format
-msgid "patterns must be specified as hex digits: %s"
-msgstr ""
-
-#: ping/node_info.c:398
-#, c-format
-msgid ""
-"ping -6 -N <nodeinfo opt>\n"
-"Help:\n"
-"  help\n"
-"Query:\n"
-"  name\n"
-"  ipv6\n"
-"  ipv6-all\n"
-"  ipv6-compatible\n"
-"  ipv6-global\n"
-"  ipv6-linklocal\n"
-"  ipv6-sitelocal\n"
-"  ipv4\n"
-"  ipv4-all\n"
-"Subject:\n"
-"  subject-ipv6=addr\n"
-"  subject-ipv4=addr\n"
-"  subject-name=name\n"
-"  subject-fqdn=name\n"
-msgstr ""
-
-#: tracepath.c:618
-#, c-format
-msgid "pktlen must be within: %d < value <= %d"
-msgstr ""
-
-#: tracepath.c:302
-#, c-format
-msgid "pmtu %d\n"
-msgstr ""
-
-#: tracepath.c:307
-#, c-format
-msgid "reached\n"
-msgstr ""
-
-#: arping.c:388
-msgid "reply"
-msgstr ""
-
-#: arping.c:388
-msgid "request"
-msgstr ""
-
-#: ping/ping_common.c:914
-#, c-format
-msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
-msgstr ""
-
-#: ping/ping6_common.c:133
-msgid "scope discrepancy among the nodes"
-msgstr ""
-
-#: ping/ping6_common.c:331
-msgid "setsockopt(IPV6_TCLASS)"
-msgstr ""
-
-#. checksum should be enabled by default and setting this
-#. * option might fail anyway.
-#.
-#: ping/ping6_common.c:280
-msgid "setsockopt(RAW_CHECKSUM) failed - try to continue"
-msgstr ""
-
-#.
-#. * checksum should be enabled by default and setting this
-#. * option might fail anyway.
-#.
 #: traceroute6.c:795
 #, c-format
 msgid "setsockopt(RAW_CHECKSUM) failed - try to continue."
-msgstr ""
-
-#: ping/ping.c:247
-#, c-format
-msgid "the decimal value of TOS bits must be in range 0-255: %d"
-msgstr ""
-
-#: ping/ping.c:189
-msgid "this will become fatal error in future"
-msgstr ""
-
-#: ping/node_info.c:319
-msgid "too long scope name"
-msgstr ""
-
-#: traceroute6.c:845
-#, c-format
-msgid "traceroute to %s (%s)"
-msgstr ""
-
-#: traceroute6.c:437
-#, c-format
-msgid "traceroute: wrote %s %d chars, ret=%d\n"
-msgstr ""
-
-#: ping/ping6_common.c:333
-msgid "traffic class is not supported"
 msgstr ""
 
 #: traceroute6.c:837
@@ -1431,34 +1426,22 @@ msgstr ""
 msgid "unknown addr %s"
 msgstr ""
 
-#: ping/ping6_common.c:453
+#: traceroute6.c:845
 #, c-format
-msgid "unknown icmp type: %u"
+msgid "traceroute to %s (%s)"
 msgstr ""
 
-#: ping/ping6_common.c:87 ping/ping.c:688 ping/ping.c:797
+#: traceroute6.c:848
 #, c-format
-msgid "unknown iface: %s"
+msgid " from %s"
 msgstr ""
 
-#: ping/ping.c:777
-msgid "unknown interface"
-msgstr ""
-
-#: ping/ping.c:578
+#: traceroute6.c:849
 #, c-format
-msgid "unknown protocol family: %d"
+msgid ", %d hops max, %d byte packets\n"
 msgstr ""
 
-#: traceroute6.c:718
-msgid "wait must be >1 sec"
-msgstr ""
-
-#: ping/ping.c:702
-msgid "warning: QOS sockopts"
-msgstr ""
-
-#: clockdiff.c:270
+#: traceroute6.c:875
 #, c-format
-msgid "wrong timestamps\n"
+msgid "  %.4f ms"
 msgstr ""

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-29 11:58-0300\n"
+"POT-Creation-Date: 2020-06-29 12:49-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: arping.c:113
 #, c-format
@@ -50,120 +51,135 @@ msgstr ""
 
 #: arping.c:285
 #, c-format
-msgid "Sent %d probes (%d broadcast(s))\n"
-msgstr ""
+msgid "Sent %d probe"
+msgid_plural "Sent %d probes"
+msgstr[0] ""
+msgstr[1] ""
 
-#: arping.c:286
+#: arping.c:289
 #, c-format
-msgid "Received %d response(s)"
-msgstr ""
-
-#: arping.c:290
-#, c-format
-msgid "%d request(s)"
-msgstr ""
+msgid "(%d broadcast)\n"
+msgid_plural "(%d broadcasts)\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #: arping.c:292
 #, c-format
-msgid "%s%d broadcast(s)"
-msgstr ""
+msgid "Received %d response"
+msgid_plural "Received %d responses"
+msgstr[0] ""
+msgstr[1] ""
 
-#: arping.c:387
+#: arping.c:298
+#, c-format
+msgid "%d request"
+msgid_plural "%d requests"
+msgstr[0] ""
+msgstr[1] ""
+
+#: arping.c:303
+#, c-format
+msgid "%d broadcast"
+msgid_plural "%d broadcasts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: arping.c:399
 msgid "Unicast"
 msgstr ""
 
-#: arping.c:387
+#: arping.c:399
 msgid "Broadcast"
 msgstr ""
 
-#: arping.c:388
+#: arping.c:400
 #, c-format
 msgid "%s from "
 msgstr ""
 
-#: arping.c:388
+#: arping.c:400
 msgid "reply"
 msgstr ""
 
-#: arping.c:388
+#: arping.c:400
 msgid "request"
 msgstr ""
 
-#: arping.c:393
+#: arping.c:405
 #, c-format
 msgid "for %s "
 msgstr ""
 
-#: arping.c:398
+#: arping.c:410
 #, c-format
 msgid "for "
 msgstr ""
 
-#: arping.c:408
+#: arping.c:420
 #, c-format
 msgid " %ld.%03ldms\n"
 msgstr ""
 
-#: arping.c:410
+#: arping.c:422
 #, c-format
 msgid " UNSOLICITED?\n"
 msgstr ""
 
-#: arping.c:561
+#: arping.c:573
 #, c-format
 msgid "Interface \"%s\" is down\n"
 msgstr ""
 
-#: arping.c:569
+#: arping.c:581
 #, c-format
 msgid "Interface \"%s\" is not ARPable\n"
 msgstr ""
 
-#: arping.c:662
+#: arping.c:674
 #, c-format
 msgid "WARNING: using default broadcast address.\n"
 msgstr ""
 
-#: arping.c:872 arping.c:875 arping.c:878 ping/ping.c:364 ping/ping.c:410
+#: arping.c:884 arping.c:887 arping.c:890 ping/ping.c:364 ping/ping.c:410
 #: ping/ping.c:418 ping/ping.c:460 ping/ping.c:463 ping/ping.c:466
 #: ping/ping.c:479 tracepath.c:472 tracepath.c:475 tracepath.c:478
 #: tracepath.c:499 traceroute6.c:688 traceroute6.c:694 traceroute6.c:697
 msgid "invalid argument"
 msgstr ""
 
-#: arping.c:944
+#: arping.c:956
 #, c-format
 msgid "Device %s not available."
 msgstr ""
 
-#: arping.c:945
+#: arping.c:957
 msgid "Suitable device could not be determined. Please, use option -I."
 msgstr ""
 
-#: arping.c:965 traceroute6.c:822
+#: arping.c:977 traceroute6.c:822
 msgid "WARNING: interface is ignored"
 msgstr ""
 
-#: arping.c:983
+#: arping.c:995
 msgid "WARNING: setsockopt(SO_DONTROUTE)"
 msgstr ""
 
-#: arping.c:1006
+#: arping.c:1018
 #, c-format
 msgid "Interface \"%s\" is not ARPable (no ll address)\n"
 msgstr ""
 
-#: arping.c:1015
+#: arping.c:1027
 #, c-format
 msgid "ARPING %s "
 msgstr ""
 
-#: arping.c:1016
+#: arping.c:1028
 #, c-format
 msgid "from %s %s\n"
 msgstr ""
 
-#: arping.c:1020
+#: arping.c:1032
 msgid "no source address in not-DAD mode"
 msgstr ""
 


### PR DESCRIPTION
*arping* has strings with counts which plural form code applies to. It could be presented in single form (probably not very often), but also in plural forms. Many languages have more then one plural form (not English case), so the use of ngettext is required.

Having that said, I tried patching it but it didn't work correctly. POT files receives the plural form strings, but building *arping* will now output the following warning:
```
../arping.c: In function ‘finish’:
../arping.c:286:14: warning: format ‘%d’ expects a matching ‘int’ argument [-Wformat=]
  286 |       "Sent %d probes",
      |             ~^
      |              |
      |              int
```
Indeed, *arping* is printing incorrectly. I'm not sure how to solve this. Help is appreciated.

By the way, this patch created on top of #280 