### PR TITLE
ping: Add missing <locale.h>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
           compiler: clang
 
         - os: linux
-          env: DISTRO=ubuntu:xenial
+          env: DISTRO=ubuntu:xenial EXTRA_BUILD_OPTS='-DUSE_GETTEXT=false'
           compiler: clang
 
         - os: linux

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -49,6 +49,7 @@
  *	net_cap_raw enabled.
  */
 
+#include "iputils_common.h"
 #include "ping.h"
 
 #include <assert.h>
@@ -178,9 +179,13 @@ static double ping_strtod(const char *str, const char *err_msg)
 		goto err;
 	errno = 0;
 
+#ifdef ENABLE_NLS
 	setlocale(LC_ALL, "C");
+#endif
 	num = strtod(str, &end);
+#ifdef ENABLE_NLS
 	setlocale(LC_ALL, "");
+#endif
 
 	if (errno || str == end || (end && *end)) {
 		error(0, 0, _("option argument contains garbage: %s"), end);


### PR DESCRIPTION
included via iputils_common.h.

This fixes broken build:
[10/22] cc -Iping/ping.p -Iping -I../ping -I. -I.. -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c99 -g -include config.h -include git-version.h -MD -MQ ping/ping.p/ping.c.o -MF ping/ping.p/ping.c.o.d -o ping/ping.p/ping.c.o -c ../ping/ping.c
FAILED: ping/ping.p/ping.c.o
cc -Iping/ping.p -Iping -I../ping -I. -I.. -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c99 -g -include config.h -include git-version.h -MD -MQ ping/ping.p/ping.c.o -MF ping/ping.p/ping.c.o.d -o ping/ping.p/ping.c.o -c ../ping/ping.c
../ping/ping.c: In function ‘ping_strtod’:
../ping/ping.c:181:2: warning: implicit declaration of function ‘setlocale’ [-Wimplicit-function-declaration]
181 |  setlocale(LC_ALL, "C");
|  ^~~~~~~~~
../ping/ping.c:181:12: error: ‘LC_ALL’ undeclared (first use in this function); did you mean ‘P_ALL’?
181 |  setlocale(LC_ALL, "C");
|            ^~~~~~
|            P_ALL
../ping/ping.c:181:12: note: each undeclared identifier is reported only once for each function it appears in

Fixes: 918e824 ping: add support for sub-second timeouts
Closes: #286

Reported-by: Noah Meyerhans <noahm@debian.org>
Signed-off-by: Petr Vorel <pvorel@suse.cz>