### PR TITLE
ping: Fix handling decimal point, document incompatibility changes

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -255,9 +255,11 @@ xml:id="man.ping">
         <listitem>
           <para>Wait
           <emphasis remap="I">interval</emphasis> seconds between
-          sending each packet. The default is to wait for one
-          second between each packet normally, or not to wait in
-          flood mode. Only super-user may set interval to values
+          sending each packet. Real number allowed with dot as
+          a decimal separator (regardless locale setup).
+          The default is to wait for one second between each packet
+          normally, or not to wait in flood mode.
+          Only super-user may set interval to values
           less than 0.2 seconds.</para>
         </listitem>
       </varlistentry>
@@ -682,6 +684,8 @@ xml:id="man.ping">
           affects only timeout in absence of any responses,
           otherwise
           <command>ping</command> waits for two RTTs.</para>
+          Real number allowed with dot as a decimal separator
+          (regardless locale setup).
         </listitem>
       </varlistentry>
     </variablelist>

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -49,7 +49,6 @@
  *	net_cap_raw enabled.
  */
 
-#include "iputils_common.h"
 #include "ping.h"
 
 #include <assert.h>
@@ -57,6 +56,7 @@
 #include <netinet/ip_icmp.h>
 #include <ifaddrs.h>
 #include <math.h>
+#include <locale.h>
 
 /* FIXME: global_rts will be removed in future */
 struct ping_rts *global_rts;
@@ -179,13 +179,13 @@ static double ping_strtod(const char *str, const char *err_msg)
 		goto err;
 	errno = 0;
 
-#ifdef ENABLE_NLS
+	/*
+	 * Here we always want to use locale regardless USE_IDN or ENABLE_NLS,
+	 * because it handles decimal point of -i/-W input options.
+	 */
 	setlocale(LC_ALL, "C");
-#endif
 	num = strtod(str, &end);
-#ifdef ENABLE_NLS
 	setlocale(LC_ALL, "");
-#endif
 
 	if (errno || str == end || (end && *end)) {
 		error(0, 0, _("option argument contains garbage: %s"), end);


### PR DESCRIPTION
and always include <locale.h>.

This effectively reverts d196177 ("ping: Add missing preprocesses checks
around setlocale() calls") which also included <locale.h> via
iputils_common.h.

Fixes: 918e824 ("ping: add support for sub-second timeouts")

This reverts commit d19617738523671a73b1d7a70a0d47cdfd8bfd5b.