### PR TITLE
Gateway address is displayed in reverse order

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1224,7 +1224,7 @@ static void pr_icmph(struct ping_rts *rts, uint8_t type, uint8_t code,
 			struct sockaddr_in sin = {
 				.sin_family = AF_INET,
 				.sin_addr =  {
-					icp ? icp->un.gateway : htonl(info)
+					icp ? icp->un.gateway : ntohl(info)
 				}
 			};
 


### PR DESCRIPTION
On ICMP redirects, the proposed gateway address is displayed in reverse order, while correctly transmitted in the ICMP packet. See output below:

dominik@host:~$ ping 10.240.1.1
PING 10.240.1.1 (10.240.1.1) 56(84) bytes of data.
From 192.168.1.1 icmp_seq=75 Redirect Host(New nexthop: 201.1.168.192)