### PR TITLE
ping: process interrupts in ping*_receive_error_msg

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1314,8 +1314,11 @@ int ping4_receive_error_msg(struct ping_rts *rts, socket_st *sock)
 	msg.msg_controllen = sizeof(cbuf);
 
 	res = recvmsg(sock->fd, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
-	if (res < 0)
+	if (res < 0) {
+		if (errno == EAGAIN || errno == EINTR)
+			local_errors++;
 		goto out;
+	}
 
 	e = NULL;
 	for (cmsgh = CMSG_FIRSTHDR(&msg); cmsgh; cmsgh = CMSG_NXTHDR(&msg, cmsgh)) {

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -481,8 +481,11 @@ int ping6_receive_error_msg(struct ping_rts *rts, socket_st *sock)
 	msg.msg_controllen = sizeof(cbuf);
 
 	res = recvmsg(sock->fd, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
-	if (res < 0)
+	if (res < 0) {
+		if (errno == EAGAIN || errno == EINTR)
+			local_errors++;
 		goto out;
+	}
 
 	e = NULL;
 	for (cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {


### PR DESCRIPTION
If `recvmsg(..., MSG_ERRQUEUE)` returned error, `ping` can misinterpret `EHOSTUNREACH` from `recvmsg` in the main loop as error that happened from his own packets and print the following message:

    ping: recvmsg: No route to host

However, this also could be an error from other ping, that was received by this process because of RAW socket. So it's better to skip this error and process it properly in the next cycle.