### PR TITLE
Issue- Observing packet loss of 1 during flood ping test Due to EINTR & EAGAIN error.  Resolved packet loss issue by modifying "ping_common.c" file. Adding- read-write for "EINTR" & "EAGAIN" error.

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -673,8 +673,11 @@ int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock,
 				 * on the socket, try to read the error queue.
 				 * Otherwise, give up.
 				 */
-				if ((errno == EAGAIN && !recv_error) ||
-				    errno == EINTR)
+				if ((errno == EINTR && !recv_error) ||
+					(errno == EAGAIN && !recv_error))
+					continue;
+
+				if (errno == EIO && !recv_error)
 					break;
 				recv_error = 0;
 				if (!fset->receive_error_msg(rts, sock)) {


### PR DESCRIPTION
Issue- Due to EINTR & EAGAIN error found ping packet loss of 1.

**Git Diff-**

-                               if ((errno == EAGAIN && !recv_error) ||
-                                   errno == EINTR)
+                               if ((errno == EINTR && !recv_error) ||
+                                       (errno == EAGAIN && !recv_error))
+                                       continue;
+
+                               if (errno == EIO && !recv_error)
                                        break;
