### PR TITLE
Ping: Resolved packet loss issue.

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -673,9 +673,9 @@ int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock,
 				 * on the socket, try to read the error queue.
 				 * Otherwise, give up.
 				 */
-				if ((errno == EAGAIN && !recv_error) ||
-				    errno == EINTR)
-					break;
+				if ((errno == EINTR && !recv_error) ||
+					(errno == EAGAIN && !recv_error))
+					continue;
 				recv_error = 0;
 				if (!fset->receive_error_msg(rts, sock)) {
 					if (errno) {


### PR DESCRIPTION
Due to EINTR & EAGAIN error found 1 packet loss during flood ping test.
Add- read-write for "EINTR" & "EAGAIN" error in "ping_common.c" file.

Signed-off-by: Anu Priya <apriya@nvidia.com>