### PR TITLE
ping: Restore -W 0 as infinite timeout

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -685,7 +685,8 @@ xml:id="man.ping">
           otherwise
           <command>ping</command> waits for two RTTs.
           Real number allowed with dot as a decimal separator
-          (regardless locale setup).</para>
+          (regardless locale setup).
+          0 means infinite timeout.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -488,7 +488,7 @@ main(int argc, char **argv)
 			double optval;
 
 			optval = ping_strtod(optarg, _("bad linger time"));
-			if (isless(optval, 0.001) || isgreater(optval, (double)INT_MAX / 1000))
+			if (isless(optval, 0) || isgreater(optval, (double)INT_MAX / 1000))
 				error(2, 0, _("bad linger time: %s"), optarg);
 			/* lingertime will be converted to usec later */
 			rts.lingertime = (int)(optval * 1000);


### PR DESCRIPTION
Fixes: 918e824 ("ping: add support for sub-second timeouts")

References: #290

Signed-off-by: Petr Vorel <pvorel@suse.cz>