### PR TITLE
tftpd: install into sbindir

### DIFF
--- a/tftpd/meson.build
+++ b/tftpd/meson.build
@@ -3,7 +3,8 @@ inc = include_directories('..')
 executable('tftpd', ['tftpd.c', 'tftpsubs.c', git_version_h],
 	include_directories : inc,
 	link_with : [libcommon],
-	install: true)
+	install: true,
+	install_dir: sbindir)
 
 subs = configuration_data()
 subs.set('sbindir', sbindir)


### PR DESCRIPTION
The xinet.d config expects the daemon to live in sbin.