### PR TITLE
tftpd: recvfile: avoid closing the file twice

### DIFF
--- a/tftpd/tftpd.c
+++ b/tftpd/tftpd.c
@@ -387,7 +387,6 @@ void recvfile(struct run_state *ctl, struct formats *pf)
 	write_behind(ctl->file, pf->f_convert);
 	if (close_stream(ctl->file))
 		syslog(LOG_ERR, "tftpd: write error: %s\n",  strerror(errno));
-	fclose(ctl->file);		/* close data file */
 
 	ap->th_opcode = htons((uint16_t)ACK);	/* send the "final" ack */
 	ap->th_block = htons(block);


### PR DESCRIPTION
The close_stream function calls fclose, so don't call it again.

This resolves an abort in glibc:

```
       Message: Process 1038079 (tftpd) of user 65534 dumped core.

                Stack trace of thread 1038079:
                #0  0x00007f5f650ed204 raise (libc.so.6 + 0x39204)
                #1  0x00007f5f650d6547 abort (libc.so.6 + 0x22547)
                #2  0x00007f5f6512f25f n/a (libc.so.6 + 0x7b25f)
                #3  0x00007f5f651372fa n/a (libc.so.6 + 0x832fa)
                #4  0x00007f5f65138dc2 n/a (libc.so.6 + 0x84dc2)
                #5  0x00007f5f65124b2f fclose (libc.so.6 + 0x70b2f)
                #6  0x000055571a50de73 recvfile (tftpd + 0x2e73)
                #7  0x000055571a50e064 tftp (tftpd + 0x3064)
                #8  0x000055571a50e387 tftpd_inetd (tftpd + 0x3387)
                #9  0x000055571a50e50f main (tftpd + 0x350f)
                #10 0x00007f5f650d7e6d __libc_start_main (libc.so.6 + 0x23e6d)
                #11 0x000055571a50d3ca _start (tftpd + 0x23ca)
```

Signed-off-by: Mike Gilbert <floppym@gentoo.org>