### PR TITLE
meson: Enable NO_SETCAP_OR_SUID by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,7 +43,7 @@ option('BUILD_MANS', type : 'boolean', value : true,
 option('BUILD_HTML_MANS', type : 'boolean', value : false,
 	description : 'Build html manuals')
 
-option('NO_SETCAP_OR_SUID', type : 'boolean', value : false,
+option('NO_SETCAP_OR_SUID', type : 'boolean', value : true,
        description : 'Disable setting setcap or setuid with build-aux/setcap-setuid.sh')
 
 option('SETCAP_OR_SUID_ARPING', type : 'boolean', value : false,


### PR DESCRIPTION
i.e. disable setcap-setuid.sh script.

IPPROTO_ICMP is supported in kernel since 3.0 for IPv4 [1] and 3.11
for IPv6 [2]. Some distros therefore disable setcap-setuid.sh script
via -DNO_SETCAP_OR_SUID=true, e.g. openSUSE [3], Fedora [4].

More distros disable it either due using IPPROTO_ICMP or for using their
own packaging script, e.g. Debian/Ubuntu [5], Gentoo [6], OpenWrt [7],
Buildroot [8].

The only requirement to use IPPROTO_ICMP is to set net.ipv4.ping_group_range [9]:
sysctl -w net.ipv4.ping_group_range="0 2147483647"
(probably already set by distro config)

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c319b4d76b9e583a5d88d6bf190e079c4e43213d
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6d0bfe22611602f36617bc7aa2ffa1bbb2f54c67
[3] https://bugzilla.opensuse.org/1174504
[4] https://fedoraproject.org/wiki/Changes/EnableSysctlPingGroupRange
[5] https://salsa.debian.org/debian/iputils/-/blob/04a8406f6c62c5d1169151f97ab05ff1f98f9ee2/debian/rules
[6] https://gitweb.gentoo.org/repo/gentoo.git/tree/net-misc/iputils/iputils-20200821-r2.ebuild
[7] https://github.com/openwrt/packages/blob/f9ec8d411c5d5fe17367043c07e5bea5ace776b2/net/iputils/Makefile
[8] https://git.busybox.net/buildroot/tree/package/iputils/iputils.mk?id=2bb26c1a1d24cdbb946bc2a77680dbc8f9c0d537
[9] https://github.com/openSUSE/aaa_base/pull/77/files

Suggested-by: Noah Meyerhans <noahm@debian.org>
Signed-off-by: Petr Vorel <pvorel@suse.cz>