### PR TITLE
rdisc: remove PrivateUsers=yes from systemd service file

### DIFF
--- a/systemd/rdisc.service.in
+++ b/systemd/rdisc.service.in
@@ -9,8 +9,8 @@ EnvironmentFile=-/etc/sysconfig/rdisc
 ExecStart=@sbindir@/rdisc -f -t $OPTIONS $SEND_ADDRESS $RECEIVE_ADDRESS
 
 AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_RAW
 PrivateTmp=yes
-PrivateUsers=yes
 ProtectSystem=strict
 ProtectHome=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
Quoting systemd.exec(5) manual page 'Specifically this means that the
process will have zero process capabilities on the host's user namespace'.
That does not combine will with CAP_NET_RAW that needs to take effect host's
namespace.

Secondlly add CapabilityBoundingSet that is will ensure capabilities are
limited to the one and only capability it needs.

Fixes: https://github.com/iputils/iputils/issues/314
Reference: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateUsers=
Signed-off-by: Sami Kerola <kerolasa@iki.fi>