### PR TITLE
ping: lower minimal interval for flooding to 2

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -65,7 +65,7 @@
 
 #define	MAXWAIT		10		/* max seconds to wait for response */
 #define MININTERVAL	10		/* Minimal interpacket gap */
-#define MINUSERINTERVAL	200		/* Minimal allowed interval for non-root */
+#define MINUSERINTERVAL	2		/* Minimal allowed interval for non-root */
 
 #define SCHINT(a)	(((a) <= MININTERVAL) ? MININTERVAL : (a))
 


### PR DESCRIPTION
NOTE: we keep minimal limit just to make sure people don't *accidentally* DoS themselves.

Fixes: #317

Reported-by: Olaf van der Spek <olafvdspek@gmail.com>
Reported-by: Noah Meyerhans <noahm@debian.org>
Suggested-by: Johannes Segitz <jsegitz@suse.de>
Signed-off-by: Petr Vorel <pvorel@suse.cz>