### PR TITLE
Roll back f7710a1 which checks payloads incorrectly, ignores all mism…

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1549,8 +1549,6 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 			return 1;
 		if (!is_ours(rts, sock, icp->un.echo.id))
 			return 1;			/* 'Twas not our ECHO */
-		if (!contains_pattern_in_payload(rts, (uint8_t *)(icp + 1)))
-			return 1;			/* 'Twas really not our ECHO */
 		if (gather_statistics(rts, (uint8_t *)icp, sizeof(*icp), cc,
 				      ntohs(icp->un.echo.sequence),
 				      reply_ttl, 0, tv, pr_addr(rts, from, sizeof *from),

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -380,7 +380,6 @@ int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);
 extern void sock_setbufs(struct ping_rts *rts, socket_st *, int alloc);
 extern void setup(struct ping_rts *rts, socket_st *);
-extern int contains_pattern_in_payload(struct ping_rts *rts, uint8_t *ptr);
 extern int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st*,
 		     uint8_t *packet, int packlen);
 extern int finish(struct ping_rts *rts);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -824,8 +824,6 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 			return 1;
 		if (!is_ours(rts, sock, icmph->icmp6_id))
 			return 1;
-	       if (!contains_pattern_in_payload(rts, (uint8_t *)(icmph + 1)))
-			return 1;	/* 'Twas really not our ECHO */
 		if (gather_statistics(rts, (uint8_t *)icmph, sizeof(*icmph), cc,
 				      ntohs(icmph->icmp6_seq),
 				      hops, 0, tv, pr_addr(rts, from, sizeof *from),

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -553,24 +553,6 @@ void setup(struct ping_rts *rts, socket_st *sock)
 	}
 }
 
-/*
- * Return 0 if pattern in payload point to be ptr did not match the pattern that was sent  
- */
-int contains_pattern_in_payload(struct ping_rts *rts, uint8_t *ptr)
-{
-	size_t i;
-	uint8_t *cp, *dp;
- 
-	/* check the data */
-	cp = ((u_char *)ptr) + sizeof(struct timeval);
-	dp = &rts->outpack[8 + sizeof(struct timeval)];
-	for (i = sizeof(struct timeval); i < rts->datalen; ++i, ++cp, ++dp) {
-		if (*cp != *dp)
-			return 0;
-	}
-	return 1;
-}
-
 int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock,
 	      uint8_t *packet, int packlen)
 {


### PR DESCRIPTION
…atch replies

- gather_statistics() already checks payloads and reports truncated packets
- f7710a1 skips all payload comparisons in gather_statistics() when it should not
- f7710a1 ignores truncated packets when it should not
- f7710a1 broke ping's historical behavior that reply payloads are checked
  against request payloads and differences (including reply truncation) are
  reported by gather_statistics(), because the change prevents execution of
  gather_statistics() entirely unless payload match is complete and the reply
  is not truncated