### PR TITLE
Fix Variance Estimate

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -903,16 +903,16 @@ int finish(struct ping_rts *rts)
 		long long tmvar;
 
 		// Add check for more than one to calculate std. dev. Will be zero otherwise.
-		if (total <= 1)
+		if (total <= 1) {
 			tmvar = 0;
-		else
+		} else {
 			if (rts->tsum < INT_MAX)
 				/* This slightly clumsy computation order is important to avoid
 			 	* integer rounding errors for small ping times. */
 				tmvar = (rts->tsum2 - ((rts->tsum * rts->tsum) / total)) / (total - 1);
 			else
-				tmvar = (rts->tsum2 / (total - 1)) - (tmavg * tmavg)*(total / (total - 1);
-
+				tmvar = (rts->tsum2 / (total - 1)) - (tmavg * tmavg) * (total / (total - 1));
+		}
 		tmdev = llsqrt(tmvar);
 
 		printf(_("rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"),

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -902,12 +902,16 @@ int finish(struct ping_rts *rts)
 		long tmavg = rts->tsum / total;
 		long long tmvar;
 
-		if (rts->tsum < INT_MAX)
-			/* This slightly clumsy computation order is important to avoid
-			 * integer rounding errors for small ping times. */
-			tmvar = (rts->tsum2 - ((rts->tsum * rts->tsum) / total)) / total;
+		// Add check for more than one to calculate std. dev. Will be zero otherwise.
+		if (total <= 1)
+			tmvar = 0;
 		else
-			tmvar = (rts->tsum2 / total) - (tmavg * tmavg);
+			if (rts->tsum < INT_MAX)
+				/* This slightly clumsy computation order is important to avoid
+			 	* integer rounding errors for small ping times. */
+				tmvar = (rts->tsum2 - ((rts->tsum * rts->tsum) / total)) / (total - 1);
+			else
+				tmvar = (rts->tsum2 / (total - 1)) - (tmavg * tmavg)*(total / (total - 1);
 
 		tmdev = llsqrt(tmvar);
 


### PR DESCRIPTION
Should fix issue #332 . For more on why this change, this wikipedia article is good: https://en.wikipedia.org/wiki/Bessel%27s_correction

Added a check to ensure more than 1 pings happened for variance to be calculated. Otherwise, there will be no variance.

Closes #332 