### PR TITLE
Meson unit tests ping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,6 @@ jobs:
 
     - name: Install
       run: ./build.sh install
+
+    - name: Run tests
+      run: ./build.sh test

--- a/build.sh
+++ b/build.sh
@@ -59,8 +59,15 @@ build()
 install()
 {
 	echo "=== install ==="
-
 	make install
+}
+
+run_tests()
+{
+	echo "=== tests ==="
+	cd $BUILD_DIR
+	meson tests
+	cd -
 }
 
 print_logs()
@@ -98,5 +105,10 @@ fi
 
 if [ -z "$1" -o "$1" = "install" ]; then
 	install
+	print_logs $?
+fi
+
+if [ -z "$1" -o "$1" = "test" ]; then
+	run_tests
 	print_logs $?
 fi

--- a/meson.build
+++ b/meson.build
@@ -371,7 +371,3 @@ output += 'sbindir: ' + sbindir + '\n'
 output += 'systemdunitdir: ' + systemdunitdir + '\n'
 
 message(output)
-
-############################################################
-# FIXME: write tests
-#test('ping to 127.0.0.1', p, args : ['-p 1', '127.0.0.1'])

--- a/ping/meson.build
+++ b/ping/meson.build
@@ -1,6 +1,6 @@
 inc = include_directories('..')
 
-executable('ping', [
+ping = executable('ping', [
 		'ping.c',
 		'ping_common.c',
 		'ping6_common.c',
@@ -26,3 +26,54 @@ if (setcap_ping)
 		setcap_path
 	)
 endif
+
+##### TESTS #####
+
+# TODO: ::1 generates DEPRECATION: ":" is not allowed in test name "ping -c1 ::1", it has been replaced with "_"
+foreach dst : [ 'localhost', '127.0.0.1', '::1' ]
+  foreach switch : [ '', '-4', '-6']
+	args = [ '-c1', dst ]
+	should_fail = false
+
+	if switch != ''
+	  args = [switch] + args
+	  if (switch == '-4' and dst == '::1') or (switch == '-6' and dst == '127.0.0.1')
+		 should_fail = true
+	  endif
+	endif
+
+	name = 'ping ' + ' '.join(args)
+	test(name, ping, args : args, should_fail : should_fail)
+  endforeach
+endforeach
+
+ping_tests_opt = [
+  [ '-c1' ],
+  [ '-c5', '-i0.1' ],
+  [ '-c1', '-I', 'lo' ],
+  [ '-c1', '-w1' ],
+  [ '-c1', '-W1' ],
+  [ '-c1', '-W1.1' ],
+]
+foreach dst : [ '127.0.0.1', '::1' ]
+  foreach args : ping_tests_opt
+	args += [ dst ]
+	name = 'ping ' + ' '.join(args)
+	test(name, ping, args : args)
+  endforeach
+endforeach
+
+ping_tests_opt_fail = [
+  [ '-c1.1' ],
+  [ '-c1', '-i0,1' ], # -c1 required to quit ping
+  [ '-I', 'nonexisting' ],
+  [ '-w0.1' ],
+  [ '-w0,1' ],
+]
+foreach dst : [ '127.0.0.1', '::1' ]
+  foreach args : ping_tests_opt_fail
+	args += [ dst ]
+	name = 'ping ' + ' '.join(args)
+	test(name, ping, args : args, should_fail : true)
+  endforeach
+endforeach


### PR DESCRIPTION
Start of implementing https://github.com/iputils/iputils/issues/243

These tests are simple meson unit tests for `ping`, which just check expected pass or fail.
This is just a start, because we need
1) cover all programs
2) implementing test framework which allows more complicated tests (e.g. to compare ping output)
I have started to adapt LTP framework (cleanup unimportant things), because for comparing output etc. I'd like use already written framework instead of reinventing a wheel in `meson`.

NOTE: originally posted as https://github.com/iputils/iputils/pull/335 and https://github.com/iputils/iputils/pull/337.