### PR TITLE
ping: Set mark (SO_MARK) on probe socket

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -715,6 +715,9 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		    setsockopt(probe_fd, IPPROTO_IP, IP_TOS, (char *)&rts->settos, sizeof(int)) < 0)
 			error(0, errno, _("warning: QOS sockopts"));
 
+		if (rts->opt_mark)
+			sock_setmark(rts->mark, probe_fd);
+
 		dst.sin_port = htons(1025);
 		if (rts->nroute)
 			dst.sin_addr.s_addr = rts->route[0];

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -380,6 +380,7 @@ char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen);
 int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);
 extern void sock_setbufs(struct ping_rts *rts, socket_st *, int alloc);
+extern void sock_setmark(unsigned int mark, int fd);
 extern void setup(struct ping_rts *rts, socket_st *);
 extern int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st*,
 		     uint8_t *packet, int packlen);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -183,6 +183,9 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		    !IN6_IS_ADDR_MC_LINKLOCAL(&rts->firsthop.sin6_addr))
 			rts->firsthop.sin6_family = AF_INET6;
 
+		if (rts->opt_mark)
+			sock_setmark(rts->mark, probe_fd);
+
 		rts->firsthop.sin6_port = htons(1025);
 		if (connect(probe_fd, (struct sockaddr *)&rts->firsthop, sizeof(rts->firsthop)) == -1) {
 			if ((errno == EHOSTUNREACH || errno == ENETUNREACH) && ai->ai_next) {


### PR DESCRIPTION
If the bind (source) IP is is not explicitly specified with "-I" then
ping creates a "probe" socket to determine the source IP.  However, if a
mark is configured with "-m", the current code does not apply this mark
to the "probe" socket.  If policy routing is configured such that the
mark affects source IP selection, then the wrong source IP will be used.
In addition, if policy routing is configured such that the destination
will be unreachable unless the mark is set, then the probe socket will
fail and ping will exit with an error.

This commit sets the mark on the probe socket in addition to the actual
ping socket.