### PR TITLE
ping: add RFC 8335 PROBE request and response functionality

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -90,6 +90,10 @@ xml:id="man.ping">
         <option>-T
         <replaceable>timestamp option</replaceable></option>
       </arg>
+      <arg choice="opt" rep="norepeat">
+	<option>-e
+	<replaceable>interface</replaceable></option>
+      </arg>
       <arg choice="opt" rep="norepeat">hop...</arg>
       <arg choice="req" rep="norepeat">destination</arg>
     </cmdsynopsis>
@@ -211,6 +215,26 @@ xml:id="man.ping">
         <listitem>
           <para>Print timestamp (unix time + microseconds as in
           gettimeofday) before each line.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>-e</option>
+	  <emphasis remap="I">interface</emphasis>
+        </term>
+        <listitem>
+	<para>Send ICMP Extended Echo (PROBE) request (RFC 8335),
+	instead of Echo Request. The PROBE request queries the node for
+	information about
+	<emphasis remap="I">interface</emphasis>
+	and prints the status of the interface, as well as if
+	<emphasis remap="I">interface</emphasis>
+	supports IPv4 and IPv6 addresses.</para>
+	<para><emphasis remap="I">interface</emphasis> can be a valid
+	interface name, interface index (ifindex), IPv4, or IPv6 address.
+	</para>
+	<para>This functionality requires Linux 5.13 or newer
+	</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -749,6 +773,11 @@ xml:id="man.ping">
     to include a timestamp which it uses in the computation of
     round trip times. If the data space is shorter, no round trip
     times are given.</para>
+    <para>If the <option>-e</option> option is selected, the ICMP
+    EXTENDED_ECHO_REQUEST packet mirrors the ICMP ECHO_REQUEST packet,
+    with an additional 4 bytes of ICMP EXTENTION header and up to
+    20 bytes of interface identifying information.
+    </para>
   </refsection>
 
   <refsection xml:id="duplicate_and_damaged_packets">

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -67,6 +67,52 @@
 #define MININTERVAL	10		/* Minimal interpacket gap */
 #define MINUSERINTERVAL	2		/* Minimal allowed interval for non-root */
 
+/* Definitions for Extended Echo (PROBE) messages */
+#ifndef ICMP_EXT_ECHO
+#define ICMP_EXT_ECHO			42
+#endif
+#ifndef ICMP_EXT_ECHOREPLY
+#define ICMP_EXT_ECHOREPLY		43
+#endif
+#ifndef ICMP_EXT_CODE_MAL_QUERY
+#define ICMP_EXT_CODE_MAL_QUERY		1
+#endif
+#ifndef ICMP_EXT_CODE_NO_IF
+#define ICMP_EXT_CODE_NO_IF		2
+#endif
+#ifndef ICMP_EXT_CODE_NO_TABLE_ENT
+#define	ICMP_EXT_CODE_NO_TABLE_ENT	3
+#endif
+#ifndef ICMP_EXT_CODE_MULT_IFS
+#define ICMP_EXT_CODE_MULT_IFS		4
+#endif
+#ifndef ICMP_EXT_ECHOREPLY_ACTIVE
+#define ICMP_EXT_ECHOREPLY_ACTIVE	(1 << 2)
+#endif
+#ifndef ICMP_EXT_ECHOREPLY_IPV4
+#define ICMP_EXT_ECHOREPLY_IPV4		(1 << 1)
+#endif
+#ifndef ICMP_EXT_ECHOREPLY_IPV6
+#define ICMP_EXT_ECHOREPLY_IPV6		1
+#endif
+#ifndef ICMP_EXT_ECHO_CTYPE_NAME
+#define ICMP_EXT_ECHO_CTYPE_NAME	1
+#endif
+#ifndef ICMP_EXT_ECHO_CTYPE_INDEX
+#define ICMP_EXT_ECHO_CTYPE_INDEX	2
+#endif
+#ifndef ICMP_EXT_ECHO_CTYPE_ADDR
+#define ICMP_EXT_ECHO_CTYPE_ADDR	3
+#endif
+#ifndef ICMP_AFI_IP
+#define ICMP_AFI_IP		1
+#endif
+#ifndef ICMP_AFI_IP6
+#define ICMP_AFI_IP6		2
+#endif
+#define IIO_AFI_POS		16
+#define IIO_ADRLEN_POS		8
+
 #define SCHINT(a)	(((a) <= MININTERVAL) ? MININTERVAL : (a))
 
 
@@ -96,6 +142,9 @@ typedef uint32_t	bitmap_t;
 # error Please MAX_DUP_CHK and/or BITMAP_SHIFT
 #endif
 
+#define    READ_VERSION(x)      (ntohs(x) >> 12)
+#define    WRITE_VERSION(x, y)  (htons(x = (x & 0x0FFF) | (y << 12)))
+
 struct rcvd_table {
 	bitmap_t bitmap[MAX_DUP_CHK / (sizeof(bitmap_t) * 8)];
 };
@@ -106,6 +155,19 @@ typedef struct socket_st {
 } socket_st;
 
 struct ping_rts;
+
+struct exthdr {
+	uint16_t	v_rsvd;
+	uint16_t	checksum;
+};
+
+struct iiohdr {
+	uint16_t	len;
+	uint8_t		class;
+	uint8_t		ctype;
+};
+
+int get_c_type(const char *interface);
 
 int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai, socket_st *sock);
 int ping4_send_probe(struct ping_rts *rts, socket_st *, void *packet, unsigned packet_size);
@@ -206,6 +268,11 @@ struct ping_rts {
 
 	/* Used only in ping_common.c */
 	int screen_width;
+
+	/* Used in sending PROBE messages */
+	uint32_t timestamp_offset;
+	char* interface;
+	int probe;
 #ifdef HAVE_LIBCAP
 	cap_value_t cap_raw;
 	cap_value_t cap_admin;

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -53,6 +53,7 @@ void usage(void)
 		"  -c <count>         stop after <count> replies\n"
 		"  -D                 print timestamps\n"
 		"  -d                 use SO_DEBUG socket option\n"
+		"  -e <interface>     send extended echo request querying <interface>\n"
 		"  -f                 flood ping\n"
 		"  -h                 print help and exit\n"
 		"  -I <interface>     either interface name or address\n"
@@ -291,6 +292,48 @@ void print_timestamp(struct ping_rts *rts)
 		printf("[%lu.%06lu] ",
 		       (unsigned long)tv.tv_sec, (unsigned long)tv.tv_usec);
 	}
+}
+
+/* Helper functions for constructing RFC 8335 PROBE messages */
+/* Verifies name is a valid linux interface name
+ * Copied from iproute2's if name check
+ */
+int check_ifname(const char *name)
+{
+	/* These checks mimic kernel checks in dev_valid_name */
+	if (*name == '\0')
+		return -1;
+	if (strlen(name) >= IFNAMSIZ)
+		return -1;
+
+	while (*name) {
+		if (*name == '/' || isspace(*name))
+			return -1;
+		++name;
+	}
+	return 0;
+}
+
+/* Determine c_type of interface */
+int get_c_type(const char *interface) {
+	struct in_addr inaddr;
+	struct in6_addr in6addr;
+
+	if(inet_pton(AF_INET, interface, &inaddr) == 1 || inet_pton(AF_INET6, interface, &in6addr) == 1)
+		return ICMP_EXT_ECHO_CTYPE_ADDR;
+	if(isalpha(interface[0])) {
+		if (check_ifname(interface) == 0)
+			return ICMP_EXT_ECHO_CTYPE_NAME;
+		else {
+			error(2, 0, "invalid interface name");
+		}
+	}
+	while (*interface) {
+		if (isalpha(*interface) || isspace(*interface))
+			return -1;
+		++interface;
+	}
+	return ICMP_EXT_ECHO_CTYPE_INDEX;
 }
 
 /*
@@ -723,7 +766,10 @@ int gather_statistics(struct ping_rts *rts, uint8_t *icmph, int icmplen,
 
 	if (rts->timing && cc >= (int)(8 + sizeof(struct timeval))) {
 		struct timeval tmp_tv;
-		memcpy(&tmp_tv, ptr, sizeof(tmp_tv));
+		if (!rts->probe)
+			memcpy(&tmp_tv, ptr, sizeof(tmp_tv));
+		else
+			memcpy(&tmp_tv, icmph + rts->timestamp_offset, sizeof(tmp_tv)); 
 
 restamp:
 		tvsub(tv, &tmp_tv);


### PR DESCRIPTION
This is a continuation of a project with slang21 and an update to the existing pull request found here: https://github.com/iputils/iputils/pull/328

This pull request adds timestamp info to the probe messages, fixes a bug in calculating the ctype of the message, and adds probing by ICMPV6 messages. 

Original pull request blurb:
RFC 8335 describes the use of extended echo requests to probe specific network interfaces. This PR adds the -e flag to the ping command to probe specific interfaces and receive responses from those interfaces. Functionality for RFC 8335 was recently included in Linux net-next.

Usage:

ping -e [interface] [address]

Interface can be specified by name, ifindex, or IPV4 or IPV6 address.

ping -e 1 10.0.0.89
PING 10.0.0.89 (10.0.0.89) 56(84) bytes of data.
Interface: 1
Status: ACTIVE IPV4 IPV6
64 bytes from 10.0.0.89: icmp_seq=1 ttl=64 time=2.30 ms

--- 10.0.0.89 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 2.298/2.298/2.298/0.000 ms