### PR TITLE
Ping: Fix ping6 binding to VRF and address

### DIFF
--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -223,6 +223,8 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 	if (rts->device) {
 		struct cmsghdr *cmsg;
 		struct in6_pktinfo *ipi;
+		int rc;
+		int errno_save;
 
 		cmsg = (struct cmsghdr *)(rts->cmsgbuf + rts->cmsglen);
 		rts->cmsglen += CMSG_SPACE(sizeof(*ipi));
@@ -233,6 +235,15 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		ipi = (struct in6_pktinfo *)CMSG_DATA(cmsg);
 		memset(ipi, 0, sizeof(*ipi));
 		ipi->ipi6_ifindex = if_name2index(rts->device);
+
+		enable_capability_raw();
+		rc = setsockopt(sock->fd, SOL_SOCKET, SO_BINDTODEVICE, rts->device, strlen(rts->device) + 1);
+		errno_save = errno;
+		disable_capability_raw();
+
+		if (rc == -1) {
+			error(2, errno_save, "SO_BINDTODEVICE %s", rts->device);
+		}
 	}
 
 	if (IN6_IS_ADDR_MULTICAST(&rts->whereto6.sin6_addr)) {


### PR DESCRIPTION
Ever since this commit in the Linux kernel:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1893ff20275b

If ping6 creates a `SOCK_RAW` socket (e.g. if `net.ipv4.ping_group_range = 1 0`) and passing both `-I <vrf_interface>` and `-I <local_ipv6_addr>`, ping will fail with:
`ping: bind icmp socket: Cannot assign requested address`

This is because `ping` doesn't actually bind to the VRF interface, while after the aforementioned patch to the kernel, binding to an IPv6 address searches only on the same l3mdev as the device the function receives. If the socket wasn't SO_BINDTODEVICE-ed, then the kernel will only search for devices that are not ensalved to an l3mdev device (= in the default VRF), which will cause the `bind()` to fail.

Note that for IPv4, `ping -4` does in fact bind to the interface if an address is passed as well.

The issue can be reproduced with:
```
ip netns add temp_netns
ip -n temp_netns link add vrf_1 type vrf table 10001
ip -n temp_netns link add lo10 type dummy
ip -n temp_netns link set lo10 master vrf_1
ip -n temp_netns link set vrf_1 up
ip -n temp_netns link set lo10 up
ip -n temp_netns link set lo up
ip -n temp_netns addr add 1:2::3:4/128 dev lo10

ip netns exec temp_netns ping -6 1:2::3:4 -I vrf_1 -I 1:2::3:4 -c 1

ip netns del temp_netns
```

(the creation of the network namespace is needed when running in Ubuntu 20, since in the default network namespace we have by default:
```
$ cat /proc/sys/net/ipv4/ping_group_range
0	2147483647
````
which causes `ping` to use a `SOCK_DGRAM` socket instead.
Either manually running
```
$ echo "1 0" > /proc/sys/net/ipv4/ping_group_range
```
or creating a new network namespace achieves the desired result).

The fix was tested in Ubuntu 20 running kernel 5.4.0-74-generic
Note that this fixes only the case of using `SOCK_RAW`. When using `SOCK_DGRAM` the kernel doesn't check the device the socket was SO_BINDTODEVICE-ed to, but only the device from `addr->sin6_scope_id` (which if none is passed, it will again only search devices in the default VRF).