### PR TITLE
setcap-setuid.sh: rdisc: Set correct caps

### DIFF
--- a/build-aux/setcap-setuid.sh
+++ b/build-aux/setcap-setuid.sh
@@ -16,7 +16,7 @@ _log() {
 case "$perm_type" in
 	caps)
 		if [ "$2" = "rdisc" ]; then
-			params="cap_net_raw,cap_net_admin+p"
+			params="cap_net_raw,cap_net_admin+ep"
 			_log "calling: $setcap $params $exec_path"
 			"$setcap" $params "$exec_path"
 		else

--- a/build-aux/setcap-setuid.sh
+++ b/build-aux/setcap-setuid.sh
@@ -15,9 +15,15 @@ _log() {
 
 case "$perm_type" in
 	caps)
-		params="cap_net_raw+p"
-		_log "calling: $setcap $params $exec_path"
-		"$setcap" $params "$exec_path"
+		if [ "$2" = "rdisc" ]; then
+			params="cap_net_raw,cap_net_admin+p"
+			_log "calling: $setcap $params $exec_path"
+			"$setcap" $params "$exec_path"
+		else
+			params="cap_net_raw+p"
+			_log "calling: $setcap $params $exec_path"
+			"$setcap" $params "$exec_path"
+		fi
 	;;
 	setuid)
 		_log "changing '$exec_path' to be setuid root executable"


### PR DESCRIPTION
rdisc requires cap_net_admin for ability to modify routing table (https://man7.org/linux/man-pages/man8/rdisc.8.html)
Added condition that checks that binary is rdisc and sets cap_net_raw and cap_net_admin to it.