### PR TITLE
systemd unit: rdisc: Fixes of capabilities and type

### DIFF
--- a/systemd/rdisc.service.in
+++ b/systemd/rdisc.service.in
@@ -5,11 +5,11 @@ Requires=network.target
 After=network.target
 
 [Service]
+Type=forking
 EnvironmentFile=-/etc/sysconfig/rdisc
-ExecStart=@sbindir@/rdisc -f -t $OPTIONS $SEND_ADDRESS $RECEIVE_ADDRESS
-
-AmbientCapabilities=CAP_NET_RAW
-CapabilityBoundingSet=CAP_NET_RAW
+ExecStart=@sbindir@/rdisc -f -v $OPTIONS $SEND_ADDRESS $RECEIVE_ADDRESS
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=yes


### PR DESCRIPTION
-t option is for testing purposes, so it's unknown for what reason it was added. So it much more nicer to replace it with -v option. -v is for detailed output verbosity. Additionally rdisc requires CAP_NET_ADMIN capability for ability to modify routing table. Without it there will be error: "ioctl (add/delete route): Operation not permitted"
Also service type must be set to "forking". Without it service will not start.