### PR TITLE
rdisc: support /etc/default/rdisc environment file

### DIFF
--- a/systemd/rdisc.service.in
+++ b/systemd/rdisc.service.in
@@ -6,6 +6,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/rdisc
+EnvironmentFile=-/etc/default/rdisc
 ExecStart=@sbindir@/rdisc -f -t $OPTIONS $SEND_ADDRESS $RECEIVE_ADDRESS
 
 AmbientCapabilities=CAP_NET_RAW


### PR DESCRIPTION
Red Hat derived distributions use /etc/sysconfig/, which Debian
derived distributions use /etc/default/ for a similar purpose.
Support Debian distributions by adding support for /etc/default/rdisc
as an optional EnvironmentFile in rdisc.service

Signed-off-by: Noah Meyerhans <noahm@debian.org>