### PR TITLE
systemd unit: rdisc: Add DynamicUser=yes

### DIFF
--- a/systemd/rdisc.service.in
+++ b/systemd/rdisc.service.in
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/default/rdisc
 ExecStart=@sbindir@/rdisc -f -t $OPTIONS $SEND_ADDRESS $RECEIVE_ADDRESS
 AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+DynamicUser=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=yes


### PR DESCRIPTION
to add extra security (sandboxing the service [1]).

Distro support: DynamicUser is supported from systemd 232 (Nov 2016),
also used in all other services.

NOTE: DynamicUser=yes implies PrivateTmp=yes (specified in all other
services) and implies RemoveIPC=yes (*not* specified).

[1] http://0pointer.net/blog/dynamic-users-with-systemd.html

Signed-off-by: Petr Vorel <pvorel@suse.cz>