### PR TITLE
meson: Fix build with enabled tests

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -1,8 +1,25 @@
 # Copyright (c) 2021 Petr Vorel <pvorel@suse.cz>
 
-subdir('arping')
-subdir('clockdiff')
-subdir('ninfod')
-subdir('ping')
-subdir('rarpd')
-subdir('tracepath')
+if build_arping == true
+  subdir('arping')
+endif
+
+if build_clockdiff == true
+  subdir('clockdiff')
+endif
+
+if build_ninfod == true
+  subdir('ninfod')
+endif
+
+if build_ping == true
+  subdir('ping')
+endif
+
+if build_rarpd == true
+  subdir('rarpd')
+endif
+
+if build_tracepath == true
+  subdir('tracepath')
+endif


### PR DESCRIPTION
The default setup:
```
$ rm -rf builddir/; meson builddir
...
test/rarpd/meson.build:3:0: ERROR: Unknown variable "rarpd".
```

Gentoo setup:
```
$ rm -rf builddir; meson builddir -DBUILD_ARPING=false # more options

test/arping/meson.build:3:0: ERROR: Unknown variable "arping".
```

Fixes: 802fade ("tests: Add -V test for all binaries")
Fixes: https://github.com/iputils/iputils/issues/365

Reported-by: Vincent Grande <shoober420@gmail.com>
Signed-off-by: Petr Vorel <petr.vorel@gmail.com>