### PR TITLE
ping: Remove 'unsupported IPv6' warning on disabled IPv6

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -150,8 +150,8 @@ static void create_socket(struct ping_rts *rts, socket_st *sock, int family,
 		/* Report error related to disabled IPv6 only when IPv6 also failed or in
 		 * verbose mode. Report other errors always.
 		 */
-		if ((errno == EAFNOSUPPORT && family == AF_INET6) ||
-		    rts->opt_verbose || requisite)
+		if ((errno == EAFNOSUPPORT && family == AF_INET6 && requisite) ||
+		    rts->opt_verbose)
 			error(0, errno, "socket");
 		if (requisite)
 			exit(2);


### PR DESCRIPTION
Regression was introduced in d141cb6 as introduced condition

`if ((errno == EAFNOSUPPORT && socktype == AF_INET6) || options & F_VERBOSE || requisite)`

was wrong, it should have been:

`if ((errno == EAFNOSUPPORT && family == AF_INET6 && requisite) || options & F_VERBOSE)`

but bug was hidden as `family == AF_INET6' was always false until otherwise correct fix 904cdb6 ("ping: AF_INET6 is address family not socket type [lgtm scan]") propagated the error.

Tested on kernel booted with ipv6.disable=1 (disabling via sysctl, i.e. `sysctl -w net.ipv6.conf.all.disable_ipv6=1; sysctl -w net.ipv6.conf.default.disable_ipv6=1` does not trigger the issue as it exit with "socket: Address family not supported by protocol" - errno EADDRNOTAVAIL).

Fixes: d141cb6 ("ping: work with older kernels that don't support ping sockets")
Closes: https://github.com/iputils/iputils/issues/293

Reported-by: lekto <lekto@o2.pl>
Suggested-by: klynastor
Signed-off-by: Petr Vorel <pvorel@suse.cz>