### PR TITLE
fix clockdiff host id down

### DIFF
--- a/clockdiff.c
+++ b/clockdiff.c
@@ -328,7 +328,7 @@ static int measure_inner_loop(struct run_state *ctl, struct measure_vars *mv)
 		if (diff < RANGE) {
 			mv->min1 = delta1;
 			mv->min2 = delta2;
-			return BREAK;
+			return GOOD;
 		}
 	}
 	return CONTINUE;
@@ -420,6 +420,8 @@ static int measure(struct run_state *ctl)
 				case BREAK:
 					escape = 1;
 					break;
+				case GOOD:
+					goto good_exit;
 				case CONTINUE:
 					continue;
 				default:
@@ -427,6 +429,7 @@ static int measure(struct run_state *ctl)
 			}
 		}
 	}
+good_exit:
 	ctl->measure_delta = (mv.min1 - mv.min2) / 2 + PROCESSING_TIME;
 	return GOOD;
 }


### PR DESCRIPTION
The clockdiff command always reports an error： host is down
Plus parameters -o and -o1 have problems
Change the code logic in this commit:https://github.com/iputils/iputils/commit/acb7fbbc48c368551d2f2da7d446d12ad7e1e172
but the commit message :The measure() was a bit too long and deeply indented (8 steps).

the issues:https://github.com/iputils/iputils/issues/326

