### PR TITLE
ping: allow pinging IPv6 multicast/anycast addresses (improved)

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -389,7 +389,8 @@ extern void common_options(int ch);
 extern int gather_statistics(struct ping_rts *rts, uint8_t *icmph, int icmplen,
 			     int cc, uint16_t seq, int hops,
 			     int csfailed, struct timeval *tv, char *from,
-			     void (*pr_reply)(uint8_t *ptr, int cc), int multicast);
+			     void (*pr_reply)(uint8_t *ptr, int cc), int multicast,
+			     int wrong_source);
 extern void print_timestamp(struct ping_rts *rts);
 void fill(struct ping_rts *rts, char *patp, unsigned char *packet, size_t packet_size);
 

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -192,6 +192,7 @@ struct ping_rts {
 	struct sockaddr_in6 source6;
 	struct sockaddr_in6 whereto6;
 	struct sockaddr_in6 firsthop6;
+	int multicast;
 
 	/* Used only in ping.c */
 	int ts_type;
@@ -201,7 +202,6 @@ struct ping_rts {
 	int optlen;
 	int settos;			/* Set TOS, Precedence or other QOS options */
 	int broadcast_pings;
-	int multicast;
 	struct sockaddr_in source;
 
 	/* Used only in ping_common.c */

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -212,6 +212,7 @@ struct ping_rts {
 #endif
 
 	/* Used only in ping6_common.c */
+	int subnet_router_anycast; /* Subnet-Router anycast (RFC 4291) */
 	struct sockaddr_in6 firsthop;
 	unsigned char cmsgbuf[4096];
 	size_t cmsglen;

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -711,7 +711,8 @@ int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock,
 int gather_statistics(struct ping_rts *rts, uint8_t *icmph, int icmplen,
 		      int cc, uint16_t seq, int hops,
 		      int csfailed, struct timeval *tv, char *from,
-		      void (*pr_reply)(uint8_t *icmph, int cc), int multicast)
+		      void (*pr_reply)(uint8_t *icmph, int cc), int multicast,
+		      int wrong_source)
 {
 	int dupflag = 0;
 	long triptime = 0;
@@ -804,10 +805,13 @@ restamp:
 				printf(_(" time=%ld.%03ld ms"), triptime / 1000,
 				       triptime % 1000);
 		}
+
 		if (dupflag && (!multicast || rts->opt_verbose))
 			printf(_(" (DUP!)"));
 		if (csfailed)
 			printf(_(" (BAD CHECKSUM!)"));
+		if (wrong_source)
+			printf(_(" (DIFFERENT ADDRESS!)"));
 
 		/* check the data */
 		cp = ((unsigned char *)ptr) + sizeof(struct timeval);

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-27 01:23+0200\n"
+"POT-Creation-Date: 2021-10-18 19:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -248,7 +248,7 @@ msgstr ""
 msgid "too long scope name"
 msgstr ""
 
-#: ping/node_info.c:344 ping/node_info.c:386 ping/ping6_common.c:267
+#: ping/node_info.c:344 ping/node_info.c:386 ping/ping6_common.c:277
 #: ping/ping.c:452 ping/ping.c:515 ping/ping.c:925
 msgid "memory allocation failed"
 msgstr ""
@@ -290,280 +290,280 @@ msgstr ""
 msgid "unknown iface: %s"
 msgstr ""
 
-#: ping/ping6_common.c:142
+#: ping/ping6_common.c:143
 msgid "scope discrepancy among the nodes"
 msgstr ""
 
-#: ping/ping6_common.c:215 ping/ping.c:756
+#: ping/ping6_common.c:216 ping/ping.c:756
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
 
-#: ping/ping6_common.c:242
+#: ping/ping6_common.c:243
 #, c-format
 msgid "multicast ping with too short interval: %d"
 msgstr ""
 
-#: ping/ping6_common.c:245
+#: ping/ping6_common.c:246
 msgid "multicast ping does not fragment"
 msgstr ""
 
-#: ping/ping6_common.c:289
+#: ping/ping6_common.c:299
 msgid "setsockopt(RAW_CHECKSUM) failed - try to continue"
 msgstr ""
 
-#: ping/ping6_common.c:315
+#: ping/ping6_common.c:325
 msgid "can't disable multicast loopback"
 msgstr ""
 
-#: ping/ping6_common.c:320
+#: ping/ping6_common.c:330
 msgid "can't set multicast hop limit"
 msgstr ""
 
-#: ping/ping6_common.c:323
+#: ping/ping6_common.c:333
 msgid "can't set unicast hop limit"
 msgstr ""
 
-#: ping/ping6_common.c:335
+#: ping/ping6_common.c:345
 msgid "can't receive hop limit"
 msgstr ""
 
-#: ping/ping6_common.c:340
+#: ping/ping6_common.c:350
 msgid "setsockopt(IPV6_TCLASS)"
 msgstr ""
 
-#: ping/ping6_common.c:342
+#: ping/ping6_common.c:352
 msgid "traffic class is not supported"
 msgstr ""
 
-#: ping/ping6_common.c:358
+#: ping/ping6_common.c:368
 msgid "can't set flowlabel"
 msgstr ""
 
-#: ping/ping6_common.c:362
+#: ping/ping6_common.c:372
 msgid "can't send flowinfo"
-msgstr ""
-
-#: ping/ping6_common.c:365
-#, c-format
-msgid "PING %s(%s) "
-msgstr ""
-
-#: ping/ping6_common.c:367
-#, c-format
-msgid ", flow 0x%05x, "
-msgstr ""
-
-#: ping/ping6_common.c:372 ping/ping.c:929
-#, c-format
-msgid "from %s %s: "
 msgstr ""
 
 #: ping/ping6_common.c:375
 #, c-format
+msgid "PING %s(%s) "
+msgstr ""
+
+#: ping/ping6_common.c:377
+#, c-format
+msgid ", flow 0x%05x, "
+msgstr ""
+
+#: ping/ping6_common.c:382 ping/ping.c:929
+#, c-format
+msgid "from %s %s: "
+msgstr ""
+
+#: ping/ping6_common.c:385
+#, c-format
 msgid "%zu data bytes\n"
 msgstr ""
 
-#: ping/ping6_common.c:390
+#: ping/ping6_common.c:400
 #, c-format
 msgid "Destination unreachable: "
 msgstr ""
 
-#: ping/ping6_common.c:393
+#: ping/ping6_common.c:403
 #, c-format
 msgid "No route"
 msgstr ""
 
-#: ping/ping6_common.c:396
+#: ping/ping6_common.c:406
 #, c-format
 msgid "Administratively prohibited"
 msgstr ""
 
-#: ping/ping6_common.c:399
+#: ping/ping6_common.c:409
 #, c-format
 msgid "Beyond scope of source address"
 msgstr ""
 
-#: ping/ping6_common.c:402
+#: ping/ping6_common.c:412
 #, c-format
 msgid "Address unreachable"
 msgstr ""
 
-#: ping/ping6_common.c:405
+#: ping/ping6_common.c:415
 #, c-format
 msgid "Port unreachable"
 msgstr ""
 
-#: ping/ping6_common.c:408
+#: ping/ping6_common.c:418
 #, c-format
 msgid "Unknown code %d"
 msgstr ""
 
-#: ping/ping6_common.c:413
+#: ping/ping6_common.c:423
 #, c-format
 msgid "Packet too big: mtu=%u"
 msgstr ""
 
-#: ping/ping6_common.c:415
+#: ping/ping6_common.c:425
 #, c-format
 msgid ", code=%d"
 msgstr ""
 
-#: ping/ping6_common.c:418
+#: ping/ping6_common.c:428
 #, c-format
 msgid "Time exceeded: "
 msgstr ""
 
-#: ping/ping6_common.c:420
+#: ping/ping6_common.c:430
 #, c-format
 msgid "Hop limit"
 msgstr ""
 
-#: ping/ping6_common.c:422
+#: ping/ping6_common.c:432
 #, c-format
 msgid "Defragmentation failure"
 msgstr ""
 
-#: ping/ping6_common.c:424
+#: ping/ping6_common.c:434
 #, c-format
 msgid "code %d"
 msgstr ""
 
-#: ping/ping6_common.c:427
+#: ping/ping6_common.c:437
 #, c-format
 msgid "Parameter problem: "
 msgstr ""
 
-#: ping/ping6_common.c:429
+#: ping/ping6_common.c:439
 #, c-format
 msgid "Wrong header field "
 msgstr ""
 
-#: ping/ping6_common.c:431
+#: ping/ping6_common.c:441
 #, c-format
 msgid "Unknown header "
 msgstr ""
 
-#: ping/ping6_common.c:433
+#: ping/ping6_common.c:443
 #, c-format
 msgid "Unknown option "
 msgstr ""
 
-#: ping/ping6_common.c:435
+#: ping/ping6_common.c:445
 #, c-format
 msgid "code %d "
 msgstr ""
 
-#: ping/ping6_common.c:436
+#: ping/ping6_common.c:446
 #, c-format
 msgid "at %u"
 msgstr ""
 
-#: ping/ping6_common.c:439
+#: ping/ping6_common.c:449
 #, c-format
 msgid "Echo request"
 msgstr ""
 
-#: ping/ping6_common.c:442
+#: ping/ping6_common.c:452
 #, c-format
 msgid "Echo reply"
 msgstr ""
 
-#: ping/ping6_common.c:445
+#: ping/ping6_common.c:455
 #, c-format
 msgid "MLD Query"
 msgstr ""
 
-#: ping/ping6_common.c:448
+#: ping/ping6_common.c:458
 #, c-format
 msgid "MLD Report"
 msgstr ""
 
-#: ping/ping6_common.c:451
+#: ping/ping6_common.c:461
 #, c-format
 msgid "MLD Reduction"
 msgstr ""
 
-#: ping/ping6_common.c:454
+#: ping/ping6_common.c:464
 #, c-format
 msgid "unknown icmp type: %u"
 msgstr ""
 
-#: ping/ping6_common.c:508
+#: ping/ping6_common.c:518
 msgid "local error"
 msgstr ""
 
-#: ping/ping6_common.c:510
+#: ping/ping6_common.c:520
 #, c-format
 msgid "local error: message too long, mtu: %u"
 msgstr ""
 
-#: ping/ping6_common.c:532 ping/ping.c:1376
+#: ping/ping6_common.c:542 ping/ping.c:1376
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr ""
 
-#: ping/ping6_common.c:639 ping/ping.c:1490
+#: ping/ping6_common.c:649 ping/ping.c:1490
 #, c-format
 msgid " icmp_seq=%u"
 msgstr ""
 
-#: ping/ping6_common.c:663 ping/ping6_common.c:724
+#: ping/ping6_common.c:673 ping/ping6_common.c:734
 #, c-format
 msgid " parse error (too short)"
 msgstr ""
 
-#: ping/ping6_common.c:677 ping/ping6_common.c:733
+#: ping/ping6_common.c:687 ping/ping6_common.c:743
 #, c-format
 msgid " parse error (truncated)"
 msgstr ""
 
-#: ping/ping6_common.c:737
+#: ping/ping6_common.c:747
 #, c-format
 msgid " unexpected error in inet_ntop(%s)"
 msgstr ""
 
-#: ping/ping6_common.c:746
+#: ping/ping6_common.c:756
 #, c-format
 msgid " (truncated)"
 msgstr ""
 
-#: ping/ping6_common.c:765
+#: ping/ping6_common.c:775
 #, c-format
 msgid " unknown qtype(0x%02x)"
 msgstr ""
 
-#: ping/ping6_common.c:769
+#: ping/ping6_common.c:779
 #, c-format
 msgid " refused"
 msgstr ""
 
-#: ping/ping6_common.c:772
+#: ping/ping6_common.c:782
 #, c-format
 msgid " unknown"
 msgstr ""
 
-#: ping/ping6_common.c:775
+#: ping/ping6_common.c:785
 #, c-format
 msgid " unknown code(%02x)"
 msgstr ""
 
-#: ping/ping6_common.c:777
+#: ping/ping6_common.c:787
 #, c-format
 msgid "; seq=%u;"
 msgstr ""
 
-#: ping/ping6_common.c:817
+#: ping/ping6_common.c:828
 #, c-format
 msgid "packet too short: %d bytes"
 msgstr ""
 
-#: ping/ping6_common.c:882 ping/ping.c:1617
+#: ping/ping6_common.c:895 ping/ping.c:1619
 #, c-format
 msgid "From %s: "
 msgstr ""
 
-#: ping/ping6_common.c:923 ping/ping.c:1702
+#: ping/ping6_common.c:936 ping/ping.c:1704
 msgid "WARNING: failed to install socket filter"
 msgstr ""
 
@@ -1001,22 +1001,22 @@ msgstr ""
 msgid "local error: message too long, mtu=%u"
 msgstr ""
 
-#: ping/ping.c:1514
+#: ping/ping.c:1515
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr ""
 
-#: ping/ping.c:1592
+#: ping/ping.c:1594
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr ""
 
-#: ping/ping.c:1595
+#: ping/ping.c:1597
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr ""
 
-#: ping/ping.c:1619
+#: ping/ping.c:1621
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr ""
@@ -1059,124 +1059,129 @@ msgstr ""
 msgid "Warning: Failed to set mark: %d"
 msgstr ""
 
-#: ping/ping_common.c:732
+#: ping/ping_common.c:733
 #, c-format
 msgid "Warning: time of day goes back (%ldus), taking countermeasures"
 msgstr ""
 
-#: ping/ping_common.c:782
+#: ping/ping_common.c:783
 #, c-format
 msgid "%d bytes from %s:"
 msgstr ""
 
-#: ping/ping_common.c:788
+#: ping/ping_common.c:789
 #, c-format
 msgid " ttl=%d"
 msgstr ""
 
-#: ping/ping_common.c:791
+#: ping/ping_common.c:792
 #, c-format
 msgid " (truncated)\n"
 msgstr ""
 
-#: ping/ping_common.c:796
+#: ping/ping_common.c:797
 #, c-format
 msgid " time=%ld ms"
 msgstr ""
 
-#: ping/ping_common.c:798
+#: ping/ping_common.c:799
 #, c-format
 msgid " time=%ld.%01ld ms"
 msgstr ""
 
-#: ping/ping_common.c:801
+#: ping/ping_common.c:802
 #, c-format
 msgid " time=%ld.%02ld ms"
 msgstr ""
 
-#: ping/ping_common.c:804
+#: ping/ping_common.c:805
 #, c-format
 msgid " time=%ld.%03ld ms"
 msgstr ""
 
-#: ping/ping_common.c:808
+#: ping/ping_common.c:810
 #, c-format
 msgid " (DUP!)"
 msgstr ""
 
-#: ping/ping_common.c:810
+#: ping/ping_common.c:812
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr ""
 
-#: ping/ping_common.c:817
+#: ping/ping_common.c:814
+#, c-format
+msgid " (DIFFERENT ADDRESS!)"
+msgstr ""
+
+#: ping/ping_common.c:821
 #, c-format
 msgid ""
 "\n"
 "wrong data byte #%zu should be 0x%x but was 0x%x"
 msgstr ""
 
-#: ping/ping_common.c:860
+#: ping/ping_common.c:864
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr ""
 
-#: ping/ping_common.c:861
+#: ping/ping_common.c:865
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr ""
 
-#: ping/ping_common.c:862
+#: ping/ping_common.c:866
 #, c-format
 msgid "%ld received"
 msgstr ""
 
-#: ping/ping_common.c:864
+#: ping/ping_common.c:868
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ""
 
-#: ping/ping_common.c:866
+#: ping/ping_common.c:870
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ""
 
-#: ping/ping_common.c:868
+#: ping/ping_common.c:872
 #, c-format
 msgid ", +%ld errors"
 msgstr ""
 
-#: ping/ping_common.c:874
+#: ping/ping_common.c:878
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ""
 
-#: ping/ping_common.c:876
+#: ping/ping_common.c:880
 #, c-format
 msgid ", time %ldms"
 msgstr ""
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:900
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 
-#: ping/ping_common.c:904
+#: ping/ping_common.c:908
 #, c-format
 msgid "%spipe %d"
 msgstr ""
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:915
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr ""
 
-#: ping/ping_common.c:929
+#: ping/ping_common.c:933
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr ""
 
-#: ping/ping_common.c:934
+#: ping/ping_common.c:938
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""


### PR DESCRIPTION
Based on https://github.com/iputils/iputils/pull/373, with changes:
* relax dropping reply (from 5e052ad), print `DIFFERENT ADDRESS!` instead - needs to update translations. Original version of this PR printed `WRONG SOURCE!`, but that could be misleading in case address is not *wrong* for other sources, also mention address is a bit more informative. 
NOTE: it'd be nice to put all warnings into `ping` man page (currently none of them is there).
* IT detect Subnet-Router anycast only for the default prefix 64. I wonder if (because Subnet-Router anycast should be on local network) prefix could be detected with netlink from local interface.