### PR TITLE
Clockdiff: fix loop and rtt

### DIFF
--- a/clockdiff.c
+++ b/clockdiff.c
@@ -328,7 +328,7 @@ static int measure_inner_loop(struct run_state *ctl, struct measure_vars *mv)
 		if (diff < RANGE) {
 			mv->min1 = delta1;
 			mv->min2 = delta2;
-			return BREAK;
+			return GOOD;
 		}
 	}
 	return CONTINUE;
@@ -420,6 +420,8 @@ static int measure(struct run_state *ctl)
 				case BREAK:
 					escape = 1;
 					break;
+				case GOOD:
+					goto good_exit;
 				case CONTINUE:
 					continue;
 				default:
@@ -427,6 +429,7 @@ static int measure(struct run_state *ctl)
 			}
 		}
 	}
+good_exit:
 	ctl->measure_delta = (mv.min1 - mv.min2) / 2 + PROCESSING_TIME;
 	return GOOD;
 }

--- a/clockdiff.c
+++ b/clockdiff.c
@@ -421,6 +421,8 @@ static int measure(struct run_state *ctl)
 					escape = 1;
 					break;
 				case GOOD:
+					ctl->rtt = 0;
+					ctl->rtt_sigma = 0;
 					goto good_exit;
 				case CONTINUE:
 					continue;


### PR DESCRIPTION
Fix of #326 

It's almost the same code that was used before [s20190324](https://github.com/iputils/iputils/releases/tag/s20190324) version (look at [s20180629](https://github.com/iputils/iputils/releases/tag/s20180629) ) for situation when diff is less then 1 ms. Additionally it include little fix for avoid return incorrect rtt value (750(187)ms and etc).