### PR TITLE
tests: do not error out if ip program cannot be found

### DIFF
--- a/test/ping/meson.build
+++ b/test/ping/meson.build
@@ -5,8 +5,8 @@
 # https://github.com/actions/virtual-environments/issues/668
 ipv6_dst = []
 ipv6_switch = []
-r = run_command('ip', '-6', 'a')
-if r.stdout().strip().contains('::1')
+ip = find_program('ip', required: false)
+if ip.found() and run_command(ip, '-6', 'a').stdout().contains('::1')
   message('IPv6 enabled')
   ipv6_dst = [ '::1' ]
   ipv6_switch = [ '-6' ]


### PR DESCRIPTION
Failure to run `ip` should produce the same results as running it and discovering that, indeed, ipv6 is not available. But meson aborted because a missing program is a stricter issue than one that simply returns non-zero. So, do an upfront check for the program and disable those tests if it cannot be found.

While we are at it, optimize the function call chain to drop an unneeded .strip() before .contains()

Fixes #383