### PR TITLE
ping: Call connect() before sending/receiving

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -31,6 +31,10 @@ xml:id="man.ping">
         <replaceable>count</replaceable></option>
       </arg>
       <arg choice="opt" rep="norepeat">
+        <option>-C
+        <replaceable>connect_sk</replaceable></option>
+      </arg>
+      <arg choice="opt" rep="norepeat">
         <option>-F
         <replaceable>flowlabel</replaceable></option>
       </arg>
@@ -192,6 +196,15 @@ xml:id="man.ping">
           <command>ping</command> waits for
           <emphasis remap="I">count</emphasis> ECHO_REPLY packets,
           until the timeout expires.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>-C</option>
+          <emphasis remap="I">connect_sk</emphasis>
+        </term>
+        <listitem>
+          <para>Call connect() syscall on socket creation</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -243,7 +243,8 @@ struct ping_rts {
 		opt_tclass:1,
 		opt_timestamp:1,
 		opt_ttl:1,
-		opt_verbose:1;
+		opt_verbose:1,
+		opt_connect_sk:1;
 };
 /* FIXME: global_rts will be removed in future */
 extern struct ping_rts *global_rts;

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -54,6 +54,7 @@ void usage(void)
 		"  -A                 use adaptive ping\n"
 		"  -B                 sticky source address\n"
 		"  -c <count>         stop after <count> replies\n"
+		"  -C                 call connect() syscall on socket creation\n"
 		"  -D                 print timestamps\n"
 		"  -d                 use SO_DEBUG socket option\n"
 		"  -e <identifier>    define identifier for ping session, default is random for\n"


### PR DESCRIPTION
Once a socket is created, the connect() syscall must be called to
connect to the remote before using send()/recv() or sendto()/recvfrom().

Note that there is an existing connect() call on the probe_fd socket,
but it is not enough as it is not the socket that is later used to
transmit/receive the ping packets.

Fixes: 33370345c7d8 ("Initial import of iputils")
Signed-off-by: Gal Pressman <gal@nvidia.com>