### PR TITLE
ping: fix -m (SO_MARK) in 32-bit archs

### DIFF
--- a/iputils_common.c
+++ b/iputils_common.c
@@ -79,8 +79,29 @@ long strtol_or_err(char const *const str, char const *const errmesg,
 	if (errno || str == end || (end && *end))
 		goto err;
 	if (num < min || max < num)
-		error(EXIT_FAILURE, 0, "%s: '%s': out of range: %lu <= value <= %lu",
+		error(EXIT_FAILURE, 0, "%s: '%s': out of range: %ld <= value <= %ld",
 		      errmesg, str,  min, max);
+	return num;
+ err:
+	error(EXIT_FAILURE, errno, "%s: '%s'", errmesg, str);
+	abort();
+}
+
+unsigned long strtoul_or_err(char const *const str, char const *const errmesg,
+		   const unsigned long min, const unsigned long max)
+{
+	unsigned long num;
+	char *end = NULL;
+
+	errno = 0;
+	if (str == NULL || *str == '\0')
+		goto err;
+	num = strtoul(str, &end, 10);
+	if (errno || str == end || (end && *end))
+		goto err;
+	if (num < min || max < num)
+		error(EXIT_FAILURE, 0, "%s: '%s'=>'%lu': out of range: %lu <= value <= %lu",
+		      errmesg, str, num, min, max);
 	return num;
  err:
 	error(EXIT_FAILURE, errno, "%s: '%s'", errmesg, str);

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -66,6 +66,8 @@ extern int close_stream(FILE *stream);
 extern void close_stdout(void);
 extern long strtol_or_err(char const *const str, char const *const errmesg,
 			  const long min, const long max);
+extern unsigned long strtoul_or_err(char const *const str, char const *const errmesg,
+			  const unsigned long min, const unsigned long max);
 extern void iputils_srand(void);
 extern void timespecsub(struct timespec *a, struct timespec *b,
 			struct timespec *res);

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -420,7 +420,7 @@ main(int argc, char **argv)
 			rts.opt_noloop = 1;
 			break;
 		case 'm':
-			rts.mark = strtol_or_err(optarg, _("invalid argument"), 0, UINT_MAX);
+			rts.mark = strtoul_or_err(optarg, _("invalid argument"), 0, UINT_MAX);
 			rts.opt_mark = 1;
 			break;
 		case 'M':

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -459,7 +459,7 @@ void sock_setmark(unsigned int mark, int fd)
 
 	/* Do not exit, old kernels do not support mark. */
 	if (ret == -1)
-		error(0, errno_save, _("WARNING: failed to set mark: %d"), mark);
+		error(0, errno_save, _("WARNING: failed to set mark: %u"), mark);
 #else
 		error(0, errno_save, _("WARNING: SO_MARK not supported"));
 #endif


### PR DESCRIPTION
strtol_or_err() uses signed int for checking boundaries. However, '-m'
uses UINT_MAX as upper limit. For 32-bit archs, that UINT_MAX becomes a
negative value, invalidating all possibe values.

A new strtoul_or_err() is now in use for '-m'. It is equal to
strtol_or_err(), but it uses unsigned variables. Most, if not all,
uses of strtol_or_err() could be replaced by strtoul_or_err().

The error message in strtol_or_err() was also fixed. It was printing
signed boundaries as unsigned ones, hiding the fact that the upper
boundary was treated as negative. The opposite was happening with
sock_setmark().

Although setsockopt(,,SO_MARK,,) treat that value as signed int, the
correct value eventually get into the kernel u32 variable.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>