### PR TITLE
arping: exit 0 if running in deadline mode and we see replies

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -848,6 +848,8 @@ static int event_loop(struct run_state *ctl)
 	else if (ctl->dad && ctl->quit_on_reply)
 		/* Duplicate address detection mode return value */
 		rc |= !(ctl->brd_sent != ctl->received);
+	else if (ctl->timeout && !(ctl->count > 0))
+		rc |= !(ctl->received > 0);
 	else
 		rc |= (ctl->sent != ctl->received);
 	return rc;

--- a/arping.c
+++ b/arping.c
@@ -759,7 +759,7 @@ static int event_loop(struct run_state *ctl)
 
 	/* timeout timerfd */
 	timeoutfd = timerfd_create(CLOCK_MONOTONIC, 0);
-	if (tfd == -1) {
+	if (timeoutfd == -1) {
 		error(0, errno, "timerfd_create failed");
 		return 1;
 	}

--- a/doc/arping.xml
+++ b/doc/arping.xml
@@ -202,13 +202,13 @@ xml:id="man.arping">
         <listitem>
           <para>Specify a timeout, in seconds, before
           <command>arping</command> exits regardless of how many
-          packets have been sent or received. In this case
-          <command>arping</command> does not stop after
-          <emphasis remap='I'>count</emphasis> packet are sent, it
-          waits either for
-          <emphasis remap='I'>deadline</emphasis> expire or until
-          <emphasis remap='I'>count</emphasis> probes are
-          answered.</para>
+          packets have been sent or received.  If any replies are
+          received, exit with status 0, otherwise status 1.  When
+          combined with the <emphasis remap="I">count</emphasis>
+          option, exit with status 0 if <emphasis
+          remap="I">count</emphasis> replies are received before the
+          deadline expiration, otherwise status 1.
+	  </para>
         </listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
As observed in #392, arping exits with an error code when running in deadline mode without a reply count requirement (`-w` without `-c`). As these options are identical to the same options in ping, and are useful to test that a host is alive, the arping behavior should match the documented behavior of ping and exit with status 0 if any replies are received before the deadline.

**Previous behavior**
```
$ arping 192.168.1.1 -I wlp0s20f3 -w3
ARPING 192.168.1.1 from 192.168.1.215 wlp0s20f3
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  3.678ms
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  3.468ms
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  3.832ms
Sent 4 probes (1 broadcast(s))
Received 3 response(s)
$ echo $?
1
$ arping 192.168.1.2 -I wlp0s20f3 -w3
ARPING 192.168.1.2 from 192.168.1.215 wlp0s20f3
Sent 4 probes (4 broadcast(s))
Received 0 response(s)
```

**New behavior** (Note the exit status)
```
$ arping 192.168.1.1 -I wlp0s20f3 -w3   
ARPING 192.168.1.1 from 192.168.1.215 wlp0s20f3
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  2.167ms
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  5.808ms
Unicast reply from 192.168.1.1 [C0:56:27:C7:CD:76]  4.206ms
Sent 4 probes (1 broadcast(s))
Received 3 response(s)
$ echo $?
0
$ arping 192.168.1.2 -I wlp0s20f3 -w3
ARPING 192.168.1.2 from 192.168.1.215 wlp0s20f3
Sent 4 probes (4 broadcast(s))
Received 0 response(s)
$ echo $?
1
```