### PR TITLE
tree: Make _GNU_SOURCE mandatory

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -10,6 +10,8 @@
  * 		YOSHIFUJI Hideaki <yoshfuji@linux-ipv6.org>
  */
 
+#define _GNU_SOURCE
+
 #include <arpa/inet.h>
 #include <errno.h>
 #include <ifaddrs.h>

--- a/clockdiff.c
+++ b/clockdiff.c
@@ -49,6 +49,8 @@
  * number of messages sent in each measurement.
  */
 
+#define _GNU_SOURCE
+
 #define TSPTYPES
 
 #include <arpa/inet.h>

--- a/iputils_common.c
+++ b/iputils_common.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio_ext.h>

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,6 @@ add_project_arguments(
 
 conf = configuration_data()
 conf.set_quoted('PACKAGE_NAME', meson.project_name())
-conf.set('_GNU_SOURCE', 1, description : 'Enable GNU extensions on systems that have them.')
 
 build_arping = get_option('BUILD_ARPING')
 build_clockdiff = get_option('BUILD_CLOCKDIFF')

--- a/ping/node_info.c
+++ b/ping/node_info.c
@@ -30,6 +30,8 @@
  * SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <stddef.h>
 
 #include "iputils_common.h"

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -49,6 +49,8 @@
  *	net_cap_raw enabled.
  */
 
+#define _GNU_SOURCE
+
 #include "ping.h"
 
 #include <assert.h>

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -1,7 +1,8 @@
 #ifndef IPUTILS_PING_H
 #define IPUTILS_PING_H
 
-/* Includes */
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -55,7 +56,6 @@
 #include <linux/types.h>
 #include <linux/errqueue.h>
 #include <linux/in6.h>
-/* All includes done. */
 
 #ifndef SCOPE_DELIMITER
 # define SCOPE_DELIMITER '%'

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -57,6 +57,9 @@
  *	if -N option is used, this program has to run SUID to ROOT or
  *	with net_cap_raw enabled.
  */
+
+#define _GNU_SOURCE
+
 #include <stddef.h>
 
 #include "iputils_common.h"

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -29,6 +29,9 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+#define _GNU_SOURCE
+
 #include "iputils_common.h"
 #include "ping.h"
 

--- a/tracepath.c
+++ b/tracepath.c
@@ -9,6 +9,8 @@
  * Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
  */
 
+#define _GNU_SOURCE
+
 #include <arpa/inet.h>
 #include <errno.h>
 #include <limits.h>


### PR DESCRIPTION
We've been relying on _GNU_SOURCE long time ago without any problems
(glibc, musl and uclibc support it):

* AI_CANONNAME (37953bf, s20150815)
* clock_gettime(), CLOCK_MONOTONIC{,_RAW}, CLOCK_REALTIME (first used in
  8c7a989, s20140519 when starting to move from obsolete gettimeofday()
  to clock_gettime(), later used more clocks across the source). glibc
  requires only _POSIX_C_SOURCE (>= 199309L), but musl _GNU_SOURCE
* gai_strerror() (used in tracepath6.c since git era - released in
  s20121106, later in 37953bf - s20150815 used in all sources)
* IFNAMSIZ (could be replaced by POSIX IF_NAMESIZE)