### PR TITLE
ping: document '%'-notation for IPv6 link-local scope address, print warning, man: add destination

### DIFF
--- a/doc/arping.xml
+++ b/doc/arping.xml
@@ -58,6 +58,11 @@ xml:id="man.arping">
     <emphasis remap="I">interface</emphasis> by ARP packets, using
     source address
     <emphasis remap="I">source</emphasis>.</para>
+    <para>arping supports IPv4 addresses only. For IPv6, see
+    <citerefentry>
+      <refentrytitle>ndisc6</refentrytitle>
+      <manvolnum>8</manvolnum>
+    </citerefentry>.</para>
   </refsection>
 
   <refsection>
@@ -227,6 +232,10 @@ xml:id="man.arping">
   <refsect1 id='see_also'>
     <title>SEE ALSO</title>
     <para>
+    <citerefentry>
+      <refentrytitle>ndisc6</refentrytitle>
+      <manvolnum>8</manvolnum>
+    </citerefentry>,
     <citerefentry>
       <refentrytitle>ping</refentrytitle>
       <manvolnum>8</manvolnum>

--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -923,7 +923,7 @@ xml:id="man.ping">
     <command>ping</command> requires CAP_NET_RAW capability to be
     executed 1) if the program is used for non-echo queries (See
     <option>-N</option> option), or 2) if kernel does not support
-    non-raw ICMP sockets, or 3) if the user is not allowed to
+    ICMP datagram sockets, or 3) if the user is not allowed to
     create an ICMP echo socket. The program may be used as set-uid
     root.</para>
   </refsection>

--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -120,6 +120,46 @@ xml:id="man.ping">
 
   <refsection>
     <info>
+      <title>IPV6 LINK-LOCAL DESTINATIONS</title>
+    </info>
+    <para>For IPv6, when the destination address has link-local scope and
+    ping is using <emphasis remap="I">ICMP datagram sockets</emphasis>,
+    the output interface must be specified.
+    When <command>ping</command> is using raw sockets, it is not strictly
+    necessary to specify the output interface but it should be done to avoid
+    ambiguity when there are multiple possible output interfaces.</para>
+    <para>There are two ways to specify the output interface:</para>
+    <variablelist remap="TP">
+      <varlistentry>
+        <term>
+          • using the
+          <emphasis remap="I">% notation</emphasis>
+        </term>
+        <listitem>
+        <para>The destination address is postfixed with
+        <emphasis remap="I">%</emphasis>
+         and the output interface name or ifindex, for example:</para>
+        <para><command>ping fe80::5054:ff:fe70:67bc%eth0</command></para>
+        <para><command>ping fe80::5054:ff:fe70:67bc%2</command></para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          • using the
+          <emphasis remap="I">-I option</emphasis>
+        </term>
+        <listitem>
+          <para>When using <emphasis remap="I">ICMP datagram sockets</emphasis>,
+          this method is only supported on some kernel versions: 5.17,
+          5.15.19, 5.10.96, 5.4.176, 4.19.228, 4.14.265.
+          Also it is not supported on musl libc.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsection>
+
+  <refsection>
+    <info>
       <title>OPTIONS</title>
     </info>
     <variablelist remap="TP">

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -558,6 +558,15 @@ main(int argc, char **argv)
 	int target_ai_family = hints.ai_family;
 	hints.ai_family = AF_UNSPEC;
 
+	unsigned char buf[sizeof(struct in6_addr)];
+	if (!strchr(target, '%') && sock6.socktype == SOCK_DGRAM &&
+		inet_pton(AF_INET6, target, buf) > 0 &&
+		(IN6_IS_ADDR_LINKLOCAL(buf) || IN6_IS_ADDR_MC_LINKLOCAL(buf))) {
+			error(0, 0, _(
+				"Warning: IPv6 link-local address on ICMP datagram socket may require ifname or scope-id"
+				" => use: address%%<ifname|scope-id>"));
+	}
+
 	ret_val = getaddrinfo(target, NULL, &hints, &result);
 	if (ret_val)
 		error(2, 0, "%s: %s", target, gai_strerror(ret_val));

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -44,7 +44,7 @@
  *	Public Domain.  Distribution Unlimited.
  * Bugs -
  *	More statistics could always be gathered.
- *	If kernel does not support non-raw ICMP sockets,
+ *	If kernel does not support ICMP datagram sockets,
  *	this program has to run SUID to ROOT or with
  *	net_cap_raw enabled.
  */

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -53,7 +53,7 @@
  *	Public Domain.  Distribution Unlimited.
  * Bugs -
  *	More statistics could always be gathered.
- *	If kernel does not support non-raw ICMP sockets or
+ *	If kernel does not support ICMP datagram sockets or
  *	if -N option is used, this program has to run SUID to ROOT or
  *	with net_cap_raw enabled.
  */


### PR DESCRIPTION
Man reason for this commit were problems described in https://github.com/iputils/iputils/issues/398.

But it looks like '%'-notation should not have an alternative in `-I<ifname|scope-id>` option, therefore in this PR:
* man/ping: document %-notation for IPv6 link-local scope address
* ping: print warning when missing on non-raw ICMP socket
* man/{ar,}ping: add destination section