### PR TITLE
Fix the problem of potential memory leakage.

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -449,6 +449,7 @@ main(int argc, char **argv)
 			break;
 		case 'p':
 			rts.opt_pingfilled = 1;
+			free(outpack_fill);
 			outpack_fill = strdup(optarg);
 			if (!outpack_fill)
 				error(2, errno, _("memory allocation failed"));


### PR DESCRIPTION
If user use '-p' opt multi-times, the previous pointer generated by
strdup functiong will be discarded.

Signed-off-by: lvgenggeng <lvgenggeng@uniontech.com>