### PR TITLE
ping: Fix socket error reporting

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -149,11 +149,7 @@ static void create_socket(struct ping_rts *rts, socket_st *sock, int family,
 	}
 
 	if (sock->fd == -1) {
-		/* Report error related to disabled IPv6 only when IPv6 also failed or in
-		 * verbose mode. Report other errors always.
-		 */
-		if ((errno == EAFNOSUPPORT && family == AF_INET6 && requisite) ||
-		    rts->opt_verbose)
+		if (requisite || rts->opt_verbose)
 			error(0, errno, "socket");
 		if (requisite)
 			exit(2);


### PR DESCRIPTION
There is actually no need for errno EAFNOSUPPORT special handling,
nor for any other errno. *All* errors needs to be reported on verbose
mode or when socket is required. If AF_INET6 socket is used with
disabled IPv6, error reporting is done by gai_strerror() (ipv6.disable=1)
or by connect() error handling in ping6_run() (EADDRNOTAVAIL on
net.ipv6.conf.all.disable_ipv6=1).

Bug was hidden because condition "errno == EAFNOSUPPORT && socktype ==
AF_INET6" introduced in d141cb6 was always false as AF_INET6 is is an address
family not a socket type, until otherwise correct fix 904cdb6. Attempt
to fix it in 79d713e introduced regression that other errors weren't
reported (e.g. EPERM on RAW socket on non-root, see #406).

Fixes: https://github.com/iputils/iputils/issues/406
Fixes: 79d713e ("ping: Remove 'unsupported IPv6' warning on disabled IPv6")
Fixes: d141cb6 ("ping: work with older kernels that don't support ping sockets")

```
Reported-by: Benjamin Poirier <benjamin.poirier@gmail.com>
Signed-off-by: Petr Vorel <pvorel@suse.cz>
```