### PR TITLE
ping: Add support for Identifier field for icmp ECHO_REQUEST

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -24,7 +24,7 @@ xml:id="man.ping">
     <cmdsynopsis sepchar=" ">
       <command>ping</command>
       <arg choice="opt" rep="norepeat">
-        <option>-aAbBdDfhLnOqrRUvV46</option>
+        <option>-aAbBdDefhLnOqrRUvV46</option>
       </arg>
       <arg choice="opt" rep="norepeat">
         <option>-c
@@ -202,6 +202,22 @@ xml:id="man.ping">
           <para>Set the SO_DEBUG option on the socket being used.
           Essentially, this socket option is not used by Linux
           kernel.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>-e</option>
+        </term>
+        <listitem>
+          <para>Set identification field of the
+          <emphasis remap="I">ECHO_REQUEST</emphasis>.
+          Setting identification to 0 implies
+          <emphasis remap="I">raw socket</emphasis>
+          option since setting zero identification on
+          <emphasis remap="I">ICMP datagram sockets</emphasis> isn't
+          supported right now. The value of the field may be printed with
+          <option>-v</option> option.
+          </para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -962,10 +978,12 @@ xml:id="man.ping">
     <para>
     <command>ping</command> requires CAP_NET_RAW capability to be
     executed 1) if the program is used for non-echo queries (See
-    <option>-N</option> option), or 2) if kernel does not support
+    <option>-N</option> option) or set zero identification field of
+    the <emphasis remap="I">ECHO_REQUEST</emphasis> (See
+    <option>-e</option>), or 2) if kernel does not support
     ICMP datagram sockets, or 3) if the user is not allowed to
-    create an ICMP echo socket. The program may be used as set-uid
-    root.</para>
+    create an ICMP echo socket. The program may be used as set-uid root.
+    </para>
   </refsection>
 
   <refsection xml:id="availability">

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -214,8 +214,9 @@ static int parseflow(char *str)
 	if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
 		cp = str + 2;
 		val = (int)strtoul(cp, &ep, 16);
-	} else
+	} else {
 		val = (int)strtoul(str, &ep, 10);
+	}
 
 	/* doesn't look like decimal or hex, eh? */
 	if (*ep != '\0')
@@ -237,8 +238,9 @@ static int parsetos(char *str)
 	if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
 		cp = str + 2;
 		tos = (int)strtol(cp, &ep, 16);
-	} else
+	} else {
 		tos = (int)strtol(str, &ep, 10);
+	}
 
 	/* doesn't look like decimal or hex, eh? */
 	if (*ep != '\0')

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -66,6 +66,7 @@
 #define	MAXWAIT		10		/* max seconds to wait for response */
 #define MININTERVAL	10		/* Minimal interpacket gap */
 #define MINUSERINTERVAL	2		/* Minimal allowed interval for non-root */
+#define IDENTIFIER_MAX	0xFFFF		/* max unsigned 2-byte value */
 
 #define SCHINT(a)	(((a) <= MININTERVAL) ? MININTERVAL : (a))
 

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -82,6 +82,8 @@ void usage(void)
 		"  -b                 allow pinging broadcast\n"
 		"  -R                 record route\n"
 		"  -T <timestamp>     define timestamp, can be one of <tsonly|tsandaddr|tsprespec>\n"
+		"  -e <identifier>    define identifier for ping session, default is random for\n"
+		"                     SOCK_RAW and kernel defined for SOCK_DGRAM\n"
 		"\nIPv6 options:\n"
 		"  -6                 use IPv6\n"
 		"  -F <flowlabel>     define flow label, default is random\n"
@@ -530,7 +532,7 @@ void setup(struct ping_rts *rts, socket_st *sock)
 			*p++ = i;
 	}
 
-	if (sock->socktype == SOCK_RAW)
+	if (sock->socktype == SOCK_RAW && rts->ident == -1)
 		rts->ident = rand() & IDENTIFIER_MAX;
 
 	set_signal(SIGINT, sigexit);
@@ -793,6 +795,9 @@ restamp:
 
 		if (pr_reply)
 			pr_reply(icmph, cc);
+
+		if (rts->opt_verbose && rts->ident != -1)
+			printf(_(" ident=%d"), ntohs(rts->ident));
 
 		if (hops >= 0)
 			printf(_(" ttl=%d"), hops);

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -531,7 +531,7 @@ void setup(struct ping_rts *rts, socket_st *sock)
 	}
 
 	if (sock->socktype == SOCK_RAW)
-		rts->ident = rand() & 0xFFFF;
+		rts->ident = rand() & IDENTIFIER_MAX;
 
 	set_signal(SIGINT, sigexit);
 	set_signal(SIGALRM, sigexit);


### PR DESCRIPTION
Sometimes I need to manually specify identifier for series of ping requests, so I decided to add this feature to the ping.
I think that not only me will find it useful.