### PR TITLE
ping: Print config options on -V

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -918,6 +918,7 @@ int main(int argc, char **argv)
 			break;
 		case 'V':
 			printf(IPUTILS_VERSION("arping"));
+			print_config();
 			exit(0);
 		case 'h':
 		case '?':

--- a/clockdiff.c
+++ b/clockdiff.c
@@ -498,6 +498,7 @@ static void parse_opts(struct run_state *ctl, int argc, char **argv)
 			break;
 		case 'V':
 			printf(IPUTILS_VERSION("clockdiff"));
+			print_config();
 			exit(0);
 		case 'h':
 			usage(0);

--- a/iputils_common.c
+++ b/iputils_common.c
@@ -161,3 +161,52 @@ void timespecsub(struct timespec *a, struct timespec *b, struct timespec *res)
 		res->tv_nsec += 1000000000L;
 	}
 }
+
+void print_config(void)
+{
+	printf(
+
+	"libcap: "
+#ifdef HAVE_LIBCAP
+	"yes"
+#else
+	"no"
+#endif
+
+	", IDN: "
+#ifdef USE_IDN
+	"yes"
+#else
+	"no"
+#endif
+
+	", NLS: "
+#ifdef ENABLE_NLS
+	"yes"
+#else
+	"no"
+#endif
+
+	", error.h: "
+#ifdef HAVE_ERROR_H
+	"yes"
+#else
+	"no"
+#endif
+
+	", getrandom(): "
+#ifdef HAVE_GETRANDOM
+	"yes"
+#else
+	"no"
+#endif
+
+	", __fpending(): "
+#ifdef HAVE___FPENDING
+	"yes"
+#else
+	"no"
+#endif
+
+	"\n");
+}

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -71,5 +71,6 @@ extern unsigned long strtoul_or_err(char const *const str, char const *const err
 extern void iputils_srand(void);
 extern void timespecsub(struct timespec *a, struct timespec *b,
 			struct timespec *res);
+void print_config(void);
 
 #endif /* IPUTILS_COMMON_H */

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -530,6 +530,7 @@ main(int argc, char **argv)
 			break;
 		case 'V':
 			printf(IPUTILS_VERSION("ping"));
+			print_config();
 			exit(0);
 		case 'w':
 			rts.deadline = strtol_or_err(optarg, _("invalid argument"), 0, INT_MAX);

--- a/tracepath.c
+++ b/tracepath.c
@@ -481,6 +481,7 @@ int main(int argc, char **argv)
 			break;
 		case 'V':
 			printf(IPUTILS_VERSION("tracepath"));
+			print_config();
 			return 0;
 		default:
 			usage();


### PR DESCRIPTION
Add to all programs (arping, clockdiff, ping, tracepath). Example:

```
$ ./ping -V
ping from iputils 20211215-58-gd746509
libcap: yes, IDN: yes, NLS: no, error.h: yes, getrandom(): yes, __fpending(): yes
```

Some info does not make sense for certain program, e.g. clockdiff uses
only libcap, but not IDN and NLS. OTOH certain headers are included for
all programs, thus kept for all.