### PR TITLE
ping: use SOCK_DGRAM for requests with non zero identification field.

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -211,7 +211,7 @@ xml:id="man.ping">
         <listitem>
           <para>Set the identification field of ECHO_REQUEST.
           Implies using <emphasis remap="I">raw socket</emphasis>,
-          for IPv4 only for id 0 (not supported on
+          only for id 0 (not supported on
           <emphasis remap="I">ICMP datagram socket</emphasis>).
           The value of the field may be printed with <option>-v</option> option.
           </para>
@@ -975,8 +975,8 @@ xml:id="man.ping">
     <para>
     <command>ping</command> requires CAP_NET_RAW capability to be
     executed 1) if the program is used for non-echo queries (see
-    <option>-N</option> option) or set the identification field of
-    ECHO_REQUEST (for IPv4 only when set to 0; see <option>-e</option>), or
+    <option>-N</option> option) or when the identification field set to 0 for
+    ECHO_REQUEST (see <option>-e</option>), or
     2) if kernel does not support ICMP datagram sockets, or
     3) if the user is not allowed to create an ICMP echo socket.
     The program may be used as set-uid root.

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -560,28 +560,19 @@ main(int argc, char **argv)
 	/* Create sockets */
 	enable_capability_raw();
 
+	/*
+	 * Current Linux kernel 6.0 doesn't support on SOCK_DGRAM setting
+	 * ident == 0
+	 */
+	if (!rts.ident)
+		hints.ai_socktype = SOCK_RAW;
+
 	if (hints.ai_family != AF_INET6) {
-
-		/*
-		 * Current Linux kernel 6.0 doesn't support on SOCK_DGRAM setting
-		 * ident == 0 on IPv4.
-		 */
-		if (!rts.ident)
-			hints.ai_socktype = SOCK_RAW;
-
 		create_socket(&rts, &sock4, AF_INET, hints.ai_socktype, IPPROTO_ICMP,
 			      hints.ai_family == AF_INET);
 	}
 
 	if (hints.ai_family != AF_INET) {
-
-		/*
-		 * Current Linux kernel 6.0 doesn't support on SOCK_DGRAM any ident
-		 * setting on IPv6.
-		 */
-		if (rts.ident >= 0)
-			hints.ai_socktype = SOCK_RAW;
-
 		create_socket(&rts, &sock6, AF_INET6, hints.ai_socktype, IPPROTO_ICMPV6, sock4.fd == -1);
 
 		/* This may not be needed if both protocol versions always had the same value, but

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -283,9 +283,14 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 			error(2, errno, "IPV6_MTU_DISCOVER");
 	}
 
-	if (rts->opt_strictsource &&
-	    bind(sock->fd, (struct sockaddr *)&rts->source6, sizeof rts->source6) == -1)
-		error(2, errno, "bind icmp socket");
+	int set_ident = rts->ident > 0 && sock->socktype == SOCK_DGRAM;
+	if (set_ident)
+		rts->source6.sin6_port = rts->ident;
+
+	if (rts->opt_strictsource || set_ident) {
+		if (bind(sock->fd, (struct sockaddr *)&rts->source6, sizeof rts->source6) == -1)
+			error(2, errno, "bind icmp socket");
+	}
 
 	if ((ssize_t)rts->datalen >= (ssize_t)sizeof(struct timeval) && (rts->ni.query < 0)) {
 		/* can we time transfer */


### PR DESCRIPTION
IPv6 supports setting non-zero identification field for ECHO_REQUEST through binding to port set to the desired value.