### PR TITLE
ping: decode unreachable codes added in RFC 4443

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -75,6 +75,16 @@
 #define MSG_CONFIRM 0
 #endif
 
+/* RFC 4443 addition not yet available in libc headers */
+#ifndef ICMP6_DST_UNREACH_POLICYFAIL
+#define ICMP6_DST_UNREACH_POLICYFAIL 5
+#endif
+
+/* RFC 4443 addition not yet available in libc headers */
+#ifndef ICMP6_DST_UNREACH_REJECTROUTE
+#define ICMP6_DST_UNREACH_REJECTROUTE 6
+#endif
+
 /*
  * MAX_DUP_CHK is the number of bits in received table, i.e. the maximum
  * number of received sequence numbers we can keep track of.

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -438,6 +438,12 @@ int print_icmp(uint8_t type, uint8_t code, uint32_t info)
 		case ICMP6_DST_UNREACH_NOPORT:
 			printf(_("Port unreachable"));
 			break;
+		case ICMP6_DST_UNREACH_POLICYFAIL:
+			printf(_("Source address failed ingress/egress policy"));
+			break;
+		case ICMP6_DST_UNREACH_REJECTROUTE:
+			printf(_("Reject route to destination"));
+			break;
 		default:
 			printf(_("Unknown code %d"), code);
 			break;


### PR DESCRIPTION
RFC 4443 added two new codes for ICMPv6 destination unreachable messages (type 1):

5 - Source address failed ingress/egress policy
6 - Reject route to destination

Before:

```
$ ping 2a03:4000:54:b9a::5
PING 2a03:4000:54:b9a::5(2a03:4000:54:b9a::5) 56 data bytes
From 2a03:4000:54:b9a::5 icmp_seq=1 Destination unreachable: Unknown code 6
From 2a03:4000:54:b9a::5 icmp_seq=2 Destination unreachable: Unknown code 6
From 2a03:4000:54:b9a::5 icmp_seq=3 Destination unreachable: Unknown code 6
```

After:

```
$ ping 2a03:4000:54:b9a::5
PING 2a03:4000:54:b9a::5(2a03:4000:54:b9a::5) 56 data bytes
From 2a03:4000:54:b9a::5 icmp_seq=1 Destination unreachable: Reject route to destination
From 2a03:4000:54:b9a::5 icmp_seq=2 Destination unreachable: Reject route to destination
From 2a03:4000:54:b9a::5 icmp_seq=3 Destination unreachable: Reject route to destination
```

Signed-off-by: Enrik Berkhan <Enrik.Berkhan@inka.de>