### PR TITLE
Improve MTU probing support in tracepath and ping

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -351,10 +351,13 @@ xml:id="man.ping">
           <para>Select Path MTU Discovery strategy.
           <emphasis remap="I">pmtudisc_option</emphasis> may be
           either
-          <emphasis remap="I">do</emphasis> (prohibit fragmentation,
-          even local one),
+          <emphasis remap="I">do</emphasis> (set DF flag but
+          subject to PMTU checks by kernel, packets too large will
+          be rejected),
           <emphasis remap="I">want</emphasis> (do PMTU discovery,
-          fragment locally when packet size is large), or
+          fragment locally when packet size is large),
+          <emphasis remap="I">probe</emphasis> (set DF flag and
+          bypass PMTU checks, useful for probing), or
           <emphasis remap="I">dont</emphasis> (do not set DF
           flag).</para>
         </listitem>

--- a/iputils_common.h
+++ b/iputils_common.h
@@ -55,6 +55,12 @@
 #ifndef IPV6_PMTUDISC_DO
 # define IPV6_PMTUDISC_DO	2
 #endif
+#ifndef IP_PMTUDISC_PROBE
+# define IP_PMTUDISC_PROBE	3
+#endif
+#ifndef IPV6_PMTUDISC_PROBE
+# define IPV6_PMTUDISC_PROBE	3
+#endif
 
 #ifdef HAVE_ERROR_H
 # include <error.h>

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -483,6 +483,8 @@ main(int argc, char **argv)
 				rts.pmtudisc = IP_PMTUDISC_DONT;
 			else if (strcmp(optarg, "want") == 0)
 				rts.pmtudisc = IP_PMTUDISC_WANT;
+			else if (strcmp(optarg, "probe") == 0)
+				rts.pmtudisc = IP_PMTUDISC_PROBE;
 			else
 				error(2, 0, _("invalid -M argument: %s"), optarg);
 			break;
@@ -599,7 +601,8 @@ main(int argc, char **argv)
 		 * since I don't know that, it's better to be safe than sorry. */
 		rts.pmtudisc = rts.pmtudisc == IP_PMTUDISC_DO	? IPV6_PMTUDISC_DO   :
 			       rts.pmtudisc == IP_PMTUDISC_DONT ? IPV6_PMTUDISC_DONT :
-			       rts.pmtudisc == IP_PMTUDISC_WANT ? IPV6_PMTUDISC_WANT : rts.pmtudisc;
+			       rts.pmtudisc == IP_PMTUDISC_WANT ? IPV6_PMTUDISC_WANT :
+			       rts.pmtudisc == IP_PMTUDISC_PROBE? IPV6_PMTUDISC_PROBE: rts.pmtudisc;
 	}
 
 	disable_capability_raw();

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -67,7 +67,7 @@ void usage(void)
 		"  -L                 suppress loopback of multicast packets\n"
 		"  -l <preload>       send <preload> number of packages while waiting replies\n"
 		"  -m <mark>          tag the packets going out\n"
-		"  -M <pmtud opt>     define mtu discovery, can be one of <do|dont|want>\n"
+		"  -M <pmtud opt>     define mtu discovery, can be one of <do|dont|want|probe>\n"
 		"  -n                 no dns name resolution\n"
 		"  -O                 report outstanding replies\n"
 		"  -p <pattern>       contents of padding byte\n"

--- a/tracepath.c
+++ b/tracepath.c
@@ -532,7 +532,7 @@ int main(int argc, char **argv)
 		if (ctl.mtu <= ctl.overhead)
 			goto pktlen_error;
 
-		on = IPV6_PMTUDISC_DO;
+		on = IPV6_PMTUDISC_PROBE;
 		if (setsockopt(ctl.socket_fd, SOL_IPV6, IPV6_MTU_DISCOVER, &on, sizeof(on)) &&
 		    (on = IPV6_PMTUDISC_DO, setsockopt(ctl.socket_fd, SOL_IPV6,
 		     IPV6_MTU_DISCOVER, &on, sizeof(on))))
@@ -557,7 +557,7 @@ int main(int argc, char **argv)
 		if (ctl.mtu <= ctl.overhead)
 			goto pktlen_error;
 
-		on = IP_PMTUDISC_DO;
+		on = IP_PMTUDISC_PROBE;
 		if (setsockopt(ctl.socket_fd, SOL_IP, IP_MTU_DISCOVER, &on, sizeof(on)))
 			error(1, errno, "IP_MTU_DISCOVER");
 		on = 1;


### PR DESCRIPTION
A regression in MTU probing feature of tracepath since 81d0f03d53138b3e100f60a50da50ec946ca866c is fixed, so that previous PMTU info cached in kernel FIB won't affect the result of tracepath. The symptom has been observed but regretfully I don't know how to reproduce it locally.

The possibility of sending such over-PMTU-sized probing packets in ping is added so users can play with different MTU manually with `ping -M probe`.

Better commit description is appreciated for both commits.

---

For the tracepath commit: Discrepancy already exists between `AF_INET6` and `AF_INET`, where the code for v6 will fallback to `IPV6_PMTUDISC_DO` if `IPV6_PMTUDISC_PROBE` is not available (probably due to old kernel versions), while code for v4 will fail if `IP_PMTUDISC_PROBE` is not available. Both options were introduced in Linux 2.6.22 (https://github.com/torvalds/linux/commit/628a5c561890a9a9a74dea017873530584aab06e). I wonder if the v4 version should do the fallback the same as v6 does.

For introducing the option into ping, I personally think the current option names to be confusing. But since they simply correspond to kernel API definition with the same name, `probe` is used in my patch following the convention. I considered using words like "ignore", "no", "off" or "force-ignore".

Documentation for `ping -M` is reworded a bit. Suggestions are appreciated.