### PR TITLE
ping: Fix the errno handling for strtod

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -214,6 +214,7 @@ static double ping_strtod(const char *str, const char *err_msg)
 {
 	double num;
 	char *end = NULL;
+	int strtod_errno = 0;
 
 	if (str == NULL || *str == '\0')
 		goto err;
@@ -225,7 +226,10 @@ static double ping_strtod(const char *str, const char *err_msg)
 	 */
 	setlocale(LC_ALL, "C");
 	num = strtod(str, &end);
+	strtod_errno = errno;
 	setlocale(LC_ALL, "");
+	/* Ignore setlocale() errno (e.g. invalid locale in env). */
+	errno = strtod_errno;
 
 	if (errno || str == end || (end && *end)) {
 		error(0, 0, _("option argument contains garbage: %s"), end);


### PR DESCRIPTION
The `setlocale(LC_ALL, "")` following the `strtod()` for the option 'i' can fail if the `LC_CTYPE` is invalid.
Hence the `errno` check following the `setlocale(LC_ALL, "")` thinks wrongly that `strtod()` failed with the `errno` and prints a warning. The `errno` got from the execution of `strtod()` is saved and restored after `setlocale()` to be checked for any errors.

Co-Developed-by: Sriram Rajagopalan <sriramr@arista.com>
Signed-off-by: Sriram Rajagopalan <sriramr@arista.com>
Signed-off-by: Jacek Tomasiak <jtomasiak@arista.com>

**To reproduce run e.g.**:
```
% LC_ALL=XXX sudo ping 8.8.8.8 -i 1.9 -c1
ping: option argument contains garbage: 
ping: this will become fatal error in the future
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=1.34 ms

--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 1.339/1.339/1.339/0.000 ms
```