### PR TITLE
fix potential memory leak

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -587,6 +587,7 @@ static int check_ifflags(struct run_state const *const ctl, unsigned int ifflags
 		if (ctl->device.name != NULL) {
 			if (!ctl->quiet)
 				printf(_("Interface \"%s\" is down\n"), ctl->device.name);
+			freeifaddrs(ctl->ifa0);
 			exit(2);
 		}
 		return -1;
@@ -595,6 +596,7 @@ static int check_ifflags(struct run_state const *const ctl, unsigned int ifflags
 		if (ctl->device.name != NULL) {
 			if (!ctl->quiet)
 				printf(_("Interface \"%s\" is not ARPable\n"), ctl->device.name);
+			freeifaddrs(ctl->ifa0);
 			exit(ctl->dad ? 0 : 2);
 		}
 		return -1;

--- a/tracepath.c
+++ b/tracepath.c
@@ -609,6 +609,10 @@ int main(int argc, char **argv)
 
  done:
 	freeaddrinfo(result);
+	if(ctl.pktbuf) {
+		free(ctl.pktbuf);
+		ctl.pktbuf = NULL;
+	}
 
 	printf(_("     Resume: pmtu %d "), ctl.mtu);
 	if (ctl.hops_to >= 0)


### PR DESCRIPTION
arping:
valgrind --leak-check=full  --show-leak-kinds=all arping 99.99.99.99  -c 2 ==2757117== Memcheck, a memory error detector
==2757117== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al. ==2757117== Using Valgrind-3.16.0 and LibVEX; rerun with -h for copyright info ==2757117== Command: arping 99.99.99.99 -c 2
==2757117==
Interface "lo" is not ARPable
==2757117==
==2757117== HEAP SUMMARY:
==2757117==     in use at exit: 2,224 bytes in 1 blocks
==2757117==   total heap usage: 78 allocs, 77 frees, 28,608 bytes allocated
==2757117==：
==2757117== 2,224 bytes in 1 blocks are still reachable in loss record 1 of 1
==2757117==    at 0x4841971: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==2757117==    by 0x49896E8: getifaddrs_internal (ifaddrs.c:417)
==2757117==    by 0x498A1A7: getifaddrs (ifaddrs.c:837)
==2757117==    by 0x10BD64: check_device (arping.c:631)
==2757117==    by 0x10CD5B: main (arping.c:971)
==2757117==
==2757117== LEAK SUMMARY:
==2757117==    definitely lost: 0 bytes in 0 blocks
==2757117==    indirectly lost: 0 bytes in 0 blocks
==2757117==      possibly lost: 0 bytes in 0 blocks
==2757117==    still reachable: 2,224 bytes in 1 blocks
==2757117==         suppressed: 0 bytes in 0 blocks
==2757117==
==2757117== For lists of detected and suppressed errors, rerun with: -s
==2757117== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

tracepath:
==2943644== 65,535 bytes in 1 blocks are still reachable in loss record 9 of 9
==2943644==    at 0x483F751: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==2943644==    by 0x10A88E: main (in /usr/bin/tracepath)


