### PR TITLE
ci: Add CentOS Stream 9 and Rocky Linux 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
             env:
               CC: clang
 
+          - container: "quay.io/centos/centos:stream9"
+            env:
+              CC: gcc
+
+          - container: "rockylinux:9"
+            env:
+              CC: gcc
+
           - container: "centos:7"
             env:
               CC: gcc
@@ -94,6 +102,7 @@ jobs:
       run: |
         export INSTALL=${{ matrix.container }}
         export DISTRO_VERSION="${INSTALL#*:}"
+        INSTALL="${INSTALL#quay.io/centos/}"
         INSTALL="${INSTALL%%:*}"
         INSTALL="${INSTALL%%/*}"
         ./ci/$INSTALL.sh

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -4,6 +4,7 @@ set -ex
 
 yum -y install \
 	clang \
+	docbook5-style-xsl \
 	gcc \
 	gettext \
 	iproute \
@@ -12,18 +13,18 @@ yum -y install \
 	make \
 	pkg-config
 
-yum -y install libidn2-devel docbook5-style-xsl || true
-
-# supported since CentOS 7 (CentOS 6 don't have python 3.5 meson dependency)
-if [ "$(basename $0)" = "centos.sh" ]; then
-	# CentOS 7: provided by epel
+if [ "$(basename $0)" = "centos.sh" ] || [ "$(basename $0)" = "rockylinux.sh" ]; then
+	# CentOS Linux 7: libidn2-devel, meson, ninja-build are provided by EPEL
 	yum -y install epel-release
 
-	# CentOS >= 8 provided by PowerTools (but epel still needed)
+	# Enable CRB (formerly PowerTools) on CentOS/RHEL/Rocky >= 8 via EPEL
+	# CentOS/RHEL/Rocky >= 8: meson and ninja-build are provided by CRB
 	if [ "$DISTRO_VERSION" != 7 ]; then
-		yum -y install dnf-plugins-core
-		yum config-manager --set-enabled powertools
+		# Update epel-release because CentOS Stream 9 ships 9-2.el9,
+		# which is unfortunately too old to provide the crb command.
+		dnf -y install 'dnf-command(config-manager)' epel-release
+		crb enable
 	fi
 fi
 
-yum -y install meson ninja-build
+yum -y install libidn2-devel meson ninja-build

--- a/ci/rockylinux.sh
+++ b/ci/rockylinux.sh
@@ -1,0 +1,1 @@
+fedora.sh


### PR DESCRIPTION
CentOS Stream 9 is the current development branch of CentOS and also the upstream of Red Hat Enterprise Linux 9, where Rocky Linux 9 is a 1:1 RHEL clone/rebuild of RHEL 9 (like CentOS Linux was previously).

This is unfortunately a mess: The CI for CentOS Linux 8 got removed from iputils with commit 931504a096788289d40aafadeeb7a844e223e567, because Red Hat terminated CentOS Linux 8 (EOL: 2021-12-31) in favor of CentOS Stream 8. However, there are no official CentOS Stream images on Docker Hub at all, only at Red Hat's Quay.io.

While I suggest hereby to add CentOS Stream 9 and Rocky Linux 9 (latter to cover RHEL 9), you might maybe dislike the quirks needed for CentOS Stream 9 via Quay.io. Adding CentOS Stream 8 does not make sense, because it reaches EOL at 2024‑05‑31. If at all, Rocky Linux 8 could make sense, because it reaches EOL at 2029-05-31.

Just let me know if you would like to see changes to this pull request.