### PR TITLE
ci/alpine.sh: Add libcap-utils

### DIFF
--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -13,6 +13,7 @@ apk add \
 	iproute2 \
 	gettext-dev \
 	libcap-dev \
+	libcap-utils \
 	libxslt \
 	make \
 	meson \


### PR DESCRIPTION
Just adding `libcap-utils` (provides `setcap`; to match other distributions), because adding `libidn2-dev` as well lets the tests fail…