### PR TITLE
clockdiff: Set ppoll timeout minimum to 1ms

### DIFF
--- a/clockdiff.c
+++ b/clockdiff.c
@@ -210,7 +210,7 @@ static int measure_inner_loop(struct run_state *ctl, struct measure_vars *mv)
 	struct pollfd p = { .fd = ctl->sock_raw, .events = POLLIN | POLLHUP };
 
 	{
-		long tmo = ctl->rtt + ctl->rtt_sigma;
+		long tmo = MAX(ctl->rtt + ctl->rtt_sigma, 1);
 
 		mv->tout.tv_sec = tmo / 1000;
 		mv->tout.tv_nsec = (tmo - (tmo / 1000) * 1000) * 1000000;


### PR DESCRIPTION
This is an improvement suggestion.

The ppoll timeout gets dynamically updated while receiving messages. However, if the network environment is good, the timeout gradually decreases to zero, which causes the ppoll to easily timeout and ultimately results in a 'host down' error. To address this, I suggest modifying the code to set the minimum timeout to 1ms. Additionally, by calculating using clockdiff, even in asymmetric network conditions, the error caused by a 1ms timeout would be only 0.5ms, which is lower than the clockdiff precision. Alternatively, a smaller timeout could also be used.