### PR TITLE
Update Debian CI environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
       matrix:
         include:
           # cross compilation builds
-          - container: "debian:testing"
+          - container: "debian:bookworm"
             env:
               ARCH: arm64
               CC: aarch64-linux-gnu-gcc
               VARIANT: cross-compile
 
-          - container: "debian:testing"
+          - container: "debian:bookworm"
             env:
               ARCH: ppc64el
               CC: powerpc64le-linux-gnu-gcc
               VARIANT: cross-compile
 
-          - container: "debian:testing"
+          - container: "debian:bookworm"
             env:
               ARCH: s390x
               CC: s390x-linux-gnu-gcc
@@ -37,7 +37,7 @@ jobs:
               EXTRA_BUILD_OPTS: "-DBUILD_HTML_MANS=false -DBUILD_MANS=false"
 
           # some non-default options
-          - container: "debian:stable"
+          - container: "debian:bullseye"
             env:
               CC: gcc
               EXTRA_BUILD_OPTS: "-DUSE_CAP=false -DUSE_IDN=false -DBUILD_ARPING=false -DBUILD_CLOCKDIFF=false -DUSE_GETTEXT=false"
@@ -74,18 +74,18 @@ jobs:
             env:
               CC: gcc
 
-          - container: "debian:testing"
+          - container: "debian:bookworm"
             env:
               CC: gcc
               EXTRA_BUILD_OPTS: "-DNO_SETCAP_OR_SUID=false"
 
-          - container: "debian:stable"
+          - container: "debian:bullseye"
             env:
               CC: gcc
 
-          - container: "debian:oldstable"
+          - container: "debian:buster"
             env:
-              CC: clang
+              CC: gcc
 
     container:
       image: ${{ matrix.container }}

--- a/ci/debian.sh
+++ b/ci/debian.sh
@@ -2,13 +2,6 @@
 # Copyright (c) 2019-2021 Petr Vorel <petr.vorel@gmail.com>
 set -ex
 
-if [ "$DISTRO_VERSION" = "oldstable" ]; then
-	cat <<EOF | tee /etc/apt/sources.list.d/stretch-backports.list
-deb http://http.debian.net/debian stretch-backports main contrib non-free
-EOF
-	BACKPORT_REPO="stretch-backports"
-fi
-
 if [ "$DISTRO_VERSION" = "xenial" ]; then
 	cat <<EOF | tee /etc/apt/sources.list.d/xenial-backports.list
 deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse
@@ -35,7 +28,3 @@ apt install -y --no-install-recommends \
 	meson \
 	pkg-config \
 	xsltproc
-
-if [ "$BACKPORT_REPO" ]; then
-	apt install -y --no-install-recommends -t $BACKPORT_REPO meson
-fi


### PR DESCRIPTION
This PR refreshes the Debian environments used in the CI configuration, as they've been out of date with respect to actual Debian releases for some time.

Use static release names corresponding to specific releases, rather than moving targets.  In other words, replace names like "stable" and "testing" with specific distros, "bullseye", "bookworm", etc.

Remove configuration that assumed that "oldstable" referred to Debian 9, as this hasn't been the case since the Debian 11 release in mid-2021 and Debian 9 is fully EOL at this point anyway.



