### PR TITLE
ping: Fix overflow on negative -i

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -436,7 +436,7 @@ main(int argc, char **argv)
 			double optval;
 
 			optval = ping_strtod(optarg, _("bad timing interval"));
-			if (isgreater(optval, (double)INT_MAX / 1000))
+			if (islessequal(optval, 0) || isgreater(optval, (double)INT_MAX / 1000))
 				error(2, 0, _("bad timing interval: %s"), optarg);
 			rts.interval = (int)(optval * 1000);
 			rts.opt_interval = 1;


### PR DESCRIPTION
Restore back check for -i <= 0.

Fixes: 918e824 ("ping: add support for sub-second timeouts")
Closes: https://github.com/iputils/iputils/issues/465