### PR TITLE
ping6: Improve handling of option '-Q'.

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -249,7 +249,6 @@ struct ping_rts {
 		opt_so_dontroute:1,
 		opt_sourceroute:1,
 		opt_strictsource:1,
-		opt_tclass:1,
 		opt_timestamp:1,
 		opt_ttl:1,
 		opt_verbose:1,

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -372,15 +372,6 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 	   )
 		error(2, errno, _("can't receive hop limit"));
 
-	if (rts->opt_tclass) {
-#ifdef IPV6_TCLASS
-		if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_TCLASS, &rts->tclass, sizeof rts->tclass) == -1)
-			error(2, errno, _("setsockopt(IPV6_TCLASS)"));
-#else
-		error(0, 0, _("traffic class is not supported"));
-#endif
-	}
-
 	if (rts->opt_flowinfo) {
 		char freq_buf[CMSG_ALIGN(sizeof(struct in6_flowlabel_req)) + rts->cmsglen];
 		struct in6_flowlabel_req *freq = (struct in6_flowlabel_req *)freq_buf;

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -182,6 +182,10 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 			disable_capability_raw();
 		}
 
+		if (rts->tclass &&
+		    setsockopt(probe_fd, IPPROTO_IPV6, IPV6_TCLASS, &rts->tclass, sizeof (rts->tclass)) <0)
+			error(2, errno, "setsockopt(IPV6_TCLASS)");
+
 		if (!IN6_IS_ADDR_LINKLOCAL(&rts->firsthop.sin6_addr) &&
 		    !IN6_IS_ADDR_MC_LINKLOCAL(&rts->firsthop.sin6_addr))
 			rts->firsthop.sin6_family = AF_INET6;


### PR DESCRIPTION
Using ping6 -Q on a system using ip-rules can fail because the probe_fd
doesn't set IPV6_TCLASS. Therefore, probe_fd might make its route
lookup in a different table than the one that will be used to really
send the packet. This is fixed by patch 1.

Patch 2 then cleans up some dead code also related to IPV6_TCLASS.
