### PR TITLE
ci: Add Rocky Linux 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
             env:
               CC: gcc
 
+          - container: "rockylinux:8"
+            env:
+              CC: gcc
+
           - container: "centos:7"
             env:
               CC: gcc

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -4,7 +4,6 @@ set -ex
 
 yum -y install \
 	clang \
-	docbook5-style-xsl \
 	gcc \
 	gettext \
 	iproute \
@@ -15,6 +14,7 @@ yum -y install \
 
 if [ "$(basename $0)" = "centos.sh" ] || [ "$(basename $0)" = "rockylinux.sh" ]; then
 	# CentOS Linux 7: libidn2-devel, meson, ninja-build are provided by EPEL
+	# CentOS/RHEL/Rocky 8: docbook5-style-xsl is provided by EPEL
 	yum -y install epel-release
 
 	# Enable CRB (formerly PowerTools) on CentOS/RHEL/Rocky >= 8 via EPEL
@@ -27,4 +27,4 @@ if [ "$(basename $0)" = "centos.sh" ] || [ "$(basename $0)" = "rockylinux.sh" ];
 	fi
 fi
 
-yum -y install libidn2-devel meson ninja-build
+yum -y install docbook5-style-xsl libidn2-devel meson ninja-build


### PR DESCRIPTION
Rocky Linux 8 is a 1:1 RHEL clone/rebuild of RHEL 8 (like CentOS Linux 8 was previously).

This adds the missing part mentioned in #457 now that docbook5-style-xsl landed in EPEL 8.