### PR TITLE
Whitespace fixes in IPv6 ping output

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -63,6 +63,8 @@
 /* FIXME: global_rts will be removed in future */
 struct ping_rts *global_rts;
 
+char *_pr_addr(struct ping_rts *rts, void *sa, socklen_t salen, int resolve_name);
+
 #ifndef ICMP_FILTER
 #define ICMP_FILTER	1
 struct icmp_filter {
@@ -1726,9 +1728,30 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 /*
  * pr_addr --
  *
- * Return an ascii host address optionally with a hostname.
+ * Return an ascii host address with reverse name resolution
  */
 char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen)
+{
+	return _pr_addr(rts, sa, salen, 1);
+}
+
+/*
+ * pr_raw_addr --
+ *
+ * Return an ascii host address.  Reverse name resolution is not performed.
+ */
+
+char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen)
+{
+	return _pr_addr(rts, sa, salen, 0);
+}
+
+/*
+ * _pr_addr --
+ *
+ * Return an ascii host address optionally with a hostname.
+ */
+char *_pr_addr(struct ping_rts *rts, void *sa, socklen_t salen, int resolve_name)
 {
 	static char buffer[4096] = "";
 	static struct sockaddr_storage last_sa;
@@ -1745,10 +1768,10 @@ char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen)
 	rts->in_pr_addr = !setjmp(rts->pr_addr_jmp);
 
 	getnameinfo(sa, salen, address, sizeof address, NULL, 0, getnameinfo_flags | NI_NUMERICHOST);
-	if (!rts->exiting && !rts->opt_numeric)
+	if (!rts->exiting && resolve_name && !rts->opt_numeric)
 		getnameinfo(sa, salen, name, sizeof name, NULL, 0, getnameinfo_flags);
 
-	if (*name)
+	if (*name && strncmp(name, address, NI_MAXHOST))
 		snprintf(buffer, sizeof buffer, "%s (%s)", name, address);
 	else
 		snprintf(buffer, sizeof buffer, "%s", address);

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -388,6 +388,7 @@ static inline int disable_capability_admin(void)	{ return modify_capability(0); 
 extern void drop_capabilities(void);
 
 char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen);
+char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen);
 
 int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -396,7 +396,7 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 			error(2, errno, _("can't send flowinfo"));
 	}
 
-	printf(_("PING %s(%s) "), rts->hostname, pr_addr(rts, &rts->whereto6, sizeof rts->whereto6));
+	printf(_("PING %s (%s) "), rts->hostname, pr_addr(rts, &rts->whereto6, sizeof rts->whereto6));
 	if (rts->flowlabel)
 		printf(_(", flow 0x%05x, "), (unsigned)ntohl(rts->flowlabel));
 	if (rts->device || rts->opt_strictsource) {

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -396,7 +396,7 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 			error(2, errno, _("can't send flowinfo"));
 	}
 
-	printf(_("PING %s (%s) "), rts->hostname, pr_addr(rts, &rts->whereto6, sizeof rts->whereto6));
+	printf(_("PING %s (%s) "), rts->hostname, pr_raw_addr(rts, &rts->whereto6, sizeof rts->whereto6));
 	if (rts->flowlabel)
 		printf(_(", flow 0x%05x, "), (unsigned)ntohl(rts->flowlabel));
 	if (rts->device || rts->opt_strictsource) {


### PR DESCRIPTION
This change makes a couple small tweaks to the IPv6 ping output to make it more consistent with the IPv4 output and less confusing.

Closes #455 

Comparison of output before and after this change when pinging a host with reverse DNS (note the "PING" line):

Before:
```plain
$ ./builddir/ping/ping -6 -c1 minas.morgul.net
PING minas.morgul.net(minas.morgul.net (2603:400a:ffff:bb8::801f:30)) 56 data bytes
64 bytes from minas.morgul.net (2603:400a:ffff:bb8::801f:30): icmp_seq=1 ttl=40 time=80.9 ms

--- minas.morgul.net ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 80.885/80.885/80.885/0.000 ms
```

After:
```plain
$ ./builddir/ping/ping -6 -c1 minas.morgul.net
PING minas.morgul.net (2603:400a:ffff:bb8::801f:30) 56 data bytes
64 bytes from minas.morgul.net (2603:400a:ffff:bb8::801f:30): icmp_seq=1 ttl=40 time=81.5 ms

--- minas.morgul.net ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 81.508/81.508/81.508/0.000 ms
```

A host without reverse DNS:

Before:
```plain
$ ./builddir/ping/ping -6 -c1 s3.dualstack.us-west-2.amazonaws.com
PING s3.dualstack.us-west-2.amazonaws.com(2600:1fa0:402c:1140:34da:dd70:: (2600:1fa0:402c:1140:34da:dd70::)) 56 data bytes
64 bytes from 2600:1fa0:402c:1140:34da:dd70:: (2600:1fa0:402c:1140:34da:dd70::): icmp_seq=1 ttl=225 time=15.0 ms

--- s3.dualstack.us-west-2.amazonaws.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 14.972/14.972/14.972/0.000 ms
```
After:
```plain
$ ./builddir/ping/ping -6 -c1 s3.dualstack.us-west-2.amazonaws.com
PING s3.dualstack.us-west-2.amazonaws.com (2600:1fa0:40c9:1a81:34da:a9d8::) 56 data bytes
64 bytes from 2600:1fa0:40c9:1a81:34da:a9d8::: icmp_seq=1 ttl=221 time=16.0 ms

--- s3.dualstack.us-west-2.amazonaws.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 15.962/15.962/15.962/0.000 ms
```

When pinging a host with name resolution disabled (with the `-n` flag), output is similar to that of a host without reverse DNS, so it changes from:

```
$ ./builddir/ping/ping -6 -c1 minas.morgul.net -n
PING minas.morgul.net(2603:400a:ffff:bb8::801f:30) 56 data bytes
64 bytes from 2603:400a:ffff:bb8::801f:30: icmp_seq=1 ttl=40 time=81.2 ms

--- minas.morgul.net ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 81.205/81.205/81.205/0.000 ms
```

to 

```
$ ./builddir/ping/ping -6 -c1 minas.morgul.net -n
PING minas.morgul.net (2603:400a:ffff:bb8::801f:30) 56 data bytes
64 bytes from 2603:400a:ffff:bb8::801f:30: icmp_seq=1 ttl=40 time=81.0 ms

--- minas.morgul.net ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 80.950/80.950/80.950/0.000 ms
```