### PR TITLE
ping: Make interval error messages more readable

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -880,7 +880,9 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 
 		if (rts->uid) {
 			if (rts->interval < MIN_MULTICAST_USER_INTERVAL_MS)
-				error(2, 0, _("broadcast ping with too short interval: %d"), rts->interval);
+				error(2, 0, _("minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or higher)"),
+					  MIN_MULTICAST_USER_INTERVAL_MS,
+					  str_interval(MIN_MULTICAST_USER_INTERVAL_MS));
 
 			if (rts->pmtudisc >= 0 && rts->pmtudisc != IP_PMTUDISC_DO)
 				error(2, 0, _("broadcast ping does not fragment"));

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -877,12 +877,15 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 
 	if (rts->broadcast_pings || IN_MULTICAST(ntohl(rts->whereto.sin_addr.s_addr))) {
 		rts->multicast = 1;
+
 		if (rts->uid) {
-			if (rts->interval < 1000)
+			if (rts->interval < MIN_MULTICAST_USER_INTERVAL_MS)
 				error(2, 0, _("broadcast ping with too short interval: %d"), rts->interval);
+
 			if (rts->pmtudisc >= 0 && rts->pmtudisc != IP_PMTUDISC_DO)
 				error(2, 0, _("broadcast ping does not fragment"));
 		}
+
 		if (rts->pmtudisc < 0)
 			rts->pmtudisc = IP_PMTUDISC_DO;
 	}

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -389,6 +389,7 @@ extern void drop_capabilities(void);
 
 char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen);
 char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen);
+char *str_interval(int interval);
 
 int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -63,11 +63,11 @@
 #define	DEFDATALEN	(64 - 8)	/* default data length */
 
 #define	MAXWAIT		10		/* max seconds to wait for response */
-#define MININTERVAL	10		/* Minimal interpacket gap */
-#define MINUSERINTERVAL	2		/* Minimal allowed interval for non-root */
+#define MIN_INTERVAL_MS	10		/* Minimal interpacket gap */
+#define MIN_USER_INTERVAL_MS	2		/* Minimal allowed interval for non-root */
 #define IDENTIFIER_MAX	0xFFFF		/* max unsigned 2-byte value */
 
-#define SCHINT(a)	(((a) <= MININTERVAL) ? MININTERVAL : (a))
+#define SCHINT(a)	(((a) <= MIN_INTERVAL_MS) ? MIN_INTERVAL_MS : (a))
 
 
 #ifndef MSG_CONFIRM

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -64,7 +64,8 @@
 
 #define	MAXWAIT		10		/* max seconds to wait for response */
 #define MIN_INTERVAL_MS	10		/* Minimal interpacket gap */
-#define MIN_USER_INTERVAL_MS	2		/* Minimal allowed interval for non-root */
+#define MIN_USER_INTERVAL_MS	2		/* Minimal allowed interval for non-root for single host ping */
+#define MIN_MULTICAST_USER_INTERVAL_MS	1000	/* Minimal allowed interval for non-root for broadcast/multicast ping */
 #define IDENTIFIER_MAX	0xFFFF		/* max unsigned 2-byte value */
 
 #define SCHINT(a)	(((a) <= MIN_INTERVAL_MS) ? MIN_INTERVAL_MS : (a))

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -264,8 +264,9 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 
 		if (rts->uid) {
 			if (rts->interval < MIN_MULTICAST_USER_INTERVAL_MS)
-				error(2, 0, _("multicast ping with too short interval: %d"),
-					    rts->interval);
+				error(2, 0, _("minimal interval for multicast ping for user must be >= %d ms, use -i %s (or higher)"),
+					  MIN_MULTICAST_USER_INTERVAL_MS,
+					  str_interval(MIN_MULTICAST_USER_INTERVAL_MS));
 
 			if (rts->pmtudisc >= 0 && rts->pmtudisc != IPV6_PMTUDISC_DO)
 				error(2, 0, _("multicast ping does not fragment"));

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -261,13 +261,16 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 
 	if (IN6_IS_ADDR_MULTICAST(&rts->whereto6.sin6_addr)) {
 		rts->multicast = 1;
+
 		if (rts->uid) {
-			if (rts->interval < 1000)
+			if (rts->interval < MIN_MULTICAST_USER_INTERVAL_MS)
 				error(2, 0, _("multicast ping with too short interval: %d"),
 					    rts->interval);
+
 			if (rts->pmtudisc >= 0 && rts->pmtudisc != IPV6_PMTUDISC_DO)
 				error(2, 0, _("multicast ping does not fragment"));
 		}
+
 		if (rts->pmtudisc < 0)
 			rts->pmtudisc = IPV6_PMTUDISC_DO;
 	}

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -484,8 +484,8 @@ void setup(struct ping_rts *rts, socket_st *sock)
 		rts->interval = 0;
 
 	if (rts->uid && rts->interval < MIN_USER_INTERVAL_MS)
-		error(2, 0, _("cannot flood; minimal interval allowed for user is %dms"),
-			  MIN_USER_INTERVAL_MS);
+		error(2, 0, _("cannot flood, minimal interval for user must be >= %d ms, use -i %s (or higher)"),
+			  MIN_USER_INTERVAL_MS, str_interval(MIN_USER_INTERVAL_MS));
 
 	if (rts->interval >= INT_MAX / rts->preload)
 		error(2, 0, _("illegal preload and/or interval: %d"), rts->interval);
@@ -963,4 +963,20 @@ void status(struct ping_rts *rts)
 inline int is_ours(struct ping_rts *rts, socket_st * sock, uint16_t id)
 {
 	return sock->socktype == SOCK_DGRAM || id == rts->ident;
+}
+
+char *str_interval(int interval)
+{
+	static char buf[14];
+
+	/*
+	 * Avoid messing with locales and floating point due the different decimal
+	 * point depending on locales.
+	 */
+	if (interval % 1000)
+		snprintf(buf, sizeof(buf), "%1i.%03i", interval/1000, interval%1000);
+	else
+		snprintf(buf, sizeof(buf), "%i", interval/1000);
+
+	return buf;
 }


### PR DESCRIPTION
Improve too low interval for user on broadcast, multicast and flood
error message.  Instead of printing "raw" interval (i.e. -i value *
1000) it's more user friendly to print requested -i value.

```
$ ./builddir/ping/ping -b 192.168.122.255 -i0.1
WARNING: pinging broadcast address
./builddir/ping/ping: minimal interval for broadcast ping for user must be >= 1000 ms, use -i 1 (or higher)

$ ./builddir/ping/ping -i0.1 ff02::1%tun0
./builddir/ping/ping: minimal interval for multicast ping for user must be >= 1000 ms, use -i 1 (or higher)
```
Too low -i value and -f for user without -i use the same message. Not
sure if this should be further improved:

```
$ ./builddir/ping/ping ::1 -f
PING ::1 (::1) 56 data bytes
./builddir/ping/ping: cannot flood, minimal interval for user must be >= 2 ms, use -i 0.002 (or higher)

$ ./builddir/ping/ping -c2 -i 0.0019 ::1
PING ::1 (::1) 56 data bytes
```
./builddir/ping/ping: cannot flood, minimal interval for user must be >= 2 ms, use -i 0.002 (or higher)

Modified strings are localized (translation update before release will be needed).

Based on discussion in: https://github.com/iputils/iputils/issues/484#issuecomment-1691025991
Related PR (changes in man page): https://github.com/iputils/iputils/pull/486