### PR TITLE
ping: Handle interval correctly in the second after booting

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -319,7 +319,7 @@ int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock)
 		return 1000;
 
 	/* Check that packets < rate*time + preload */
-	if (rts->cur_time.tv_sec == 0) {
+	if (rts->cur_time.tv_sec == 0 && rts->cur_time.tv_nsec == 0) {
 		clock_gettime(CLOCK_MONOTONIC_RAW, &rts->cur_time);
 		tokens = rts->interval * (rts->preload - 1);
 	} else {

--- a/tracepath.c
+++ b/tracepath.c
@@ -192,7 +192,7 @@ static int recverr(struct run_state *const ctl)
 		ctl->his[slot].hops = 0;
 	}
 	if (recv_size == sizeof(rcvbuf)) {
-		if (rcvbuf.ttl == 0 || rcvbuf.ts.tv_sec == 0)
+		if (rcvbuf.ttl == 0 || (rcvbuf.ts.tv_sec == 0 && rcvbuf.ts.tv_nsec == 0))
 			broken_router = 1;
 		else {
 			sndhops = rcvbuf.ttl;


### PR DESCRIPTION
ping assumes that if a timespec has `tv_sec == 0`, it hasn't been initialized
yet. However, in the second after booting up, `tv_sec` will legitimately be 0.
This causes ping to send pings one after another without waiting.

Check that `tv_nsec` is 0 as well, which fixes the interval handling to wait
between pings.

Fix a similar issue in tracepath, as well.
