### PR TITLE
ping: More precise check for our packet

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -391,7 +391,7 @@ char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen);
 char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen);
 char *str_interval(int interval);
 
-int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
+int is_ours(struct ping_rts *rts, socket_st * sock, uint16_t id, uint16_t seq);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);
 extern void sock_setbufs(struct ping_rts *rts, socket_st *, int alloc);
 extern void sock_setmark(unsigned int mark, int fd);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -554,7 +554,7 @@ int ping6_receive_error_msg(struct ping_rts *rts, socket_st *sock)
 		if ((size_t)res < sizeof(icmph) ||
 		    memcmp(&target.sin6_addr, &rts->whereto6.sin6_addr, 16) ||
 		    icmph.icmp6_type != ICMP6_ECHO_REQUEST ||
-		    !is_ours(rts, sock, icmph.icmp6_id)) {
+		    !is_ours(rts, sock, icmph.icmp6_id, icmph.icmp6_seq)) {
 			/* Not our error, not an error at all. Clear. */
 			saved_errno = 0;
 			goto out;
@@ -858,7 +858,7 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 	}
 
 	if (icmph->icmp6_type == ICMP6_ECHO_REPLY) {
-		if (!is_ours(rts, sock, icmph->icmp6_id))
+		if (!is_ours(rts, sock, icmph->icmp6_id, icmph->icmp6_seq))
 			return 1;
 
 		if (!rts->multicast && !rts->subnet_router_anycast &&
@@ -910,7 +910,7 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 		}
 		if (nexthdr == IPPROTO_ICMPV6) {
 			if (icmph1->icmp6_type != ICMP6_ECHO_REQUEST ||
-			    !is_ours(rts, sock, icmph1->icmp6_id))
+			    !is_ours(rts, sock, icmph1->icmp6_id, icmph->icmp6_seq))
 				return 1;
 			acknowledge(rts, ntohs(icmph1->icmp6_seq));
 			return 0;

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -960,9 +960,10 @@ void status(struct ping_rts *rts)
 	fprintf(stderr, "\n");
 }
 
-inline int is_ours(struct ping_rts *rts, socket_st * sock, uint16_t id)
+inline int is_ours(struct ping_rts *rts, socket_st * sock, uint16_t id, uint16_t seq)
 {
-	return sock->socktype == SOCK_DGRAM || id == rts->ident;
+	return (sock->socktype == SOCK_DGRAM || id == rts->ident) &&
+		seq == ntohs(rts->ntransmitted);
 }
 
 char *str_interval(int interval)


### PR DESCRIPTION
Ping run with Nagios via Debian specific check-host-alive Nagios plugin (e.g. ping -n -v -D -W 1 -i 1 -c 5 -M 'do' -s 56 -O "$Host") can run many ping in parallel (e.g. 75-100 in the reported issue).

This leads to the collisions, because ICMP identification field is only 16 bits (65535). The problem is not new, but it was hidden until 5f6bec5 ("ping: Print reply with wrong source with warning")

We consider this warning useful, therefore instead of reverting another check for sequence was added.

Other possible solutions to this:

* Revert 5026c22 ("ping: use random value for the identifier field") Ping in the past used PID as ICMP identification field. This was considered insecure, thus it was changed to use pseudo random number in 5026c22 ("ping: use random value for the identifier field") although there is no CVE and the same approach is used in fping and busybox's ping, thus it's questionable if it was really needed.

* Add another check in the ICMP optional data We could add 128 bit random value to check. But we already use struct timeval if packet size is big enough for it (>= 16 bits), therefore we could use it for comparing for most of the packet sizes (the default is 56 bits).

Fixes: https://github.com/iputils/iputils/issues/489
Reported-by: Miloslav Hůla <miloslav.hula@gmail.com>