### PR TITLE
ping: arping: Properly fix -Wpedantic warnings

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -725,8 +725,7 @@ static int event_loop(struct run_state *ctl)
 	uint64_t exp, total_expires = 1;
 
 	unsigned char packet[4096];
-	struct sockaddr_storage from;
-	memset(&from, 0, sizeof(from));
+	struct sockaddr_storage from = {0};
 	socklen_t addr_len = sizeof(from);
 
 	/* signalfd */

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1770,12 +1770,11 @@ char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen)
 char *_pr_addr(struct ping_rts *rts, void *sa, socklen_t salen, int resolve_name)
 {
 	static char buffer[4096] = "";
-	static struct sockaddr_storage last_sa;
+	static struct sockaddr_storage last_sa = {0};
 	static socklen_t last_salen = 0;
 	char name[NI_MAXHOST] = "";
 	char address[NI_MAXHOST] = "";
 
-	memset(&last_sa, 0, sizeof(last_sa));
 	if (salen == last_salen && !memcmp(sa, &last_sa, salen))
 		return buffer;
 


### PR DESCRIPTION
7c4049b tried to fix -Wpedantic warnings:

    ../ping/ping.c: In function ‘_pr_addr’:
    ../ping/ping.c:1769:50: warning: ISO C forbids empty initializer braces before C2X [-Wpedantic]
     1769 |         static struct sockaddr_storage last_sa = {};
	  |                                                  ^
    [28/31] Compiling C object arping.p/arping.c.o
    ../arping.c: In function ‘event_loop’:
    ../arping.c:728:40: warning: ISO C forbids empty initializer braces before C2X [-Wpedantic]
      728 |         struct sockaddr_storage from = {};
	  |                                        ^

with `memset()`. But that caused another problem: when target have multiple IP addresses, last entries sometimes lost DNS record ("dns.google"):

    $ ./builddir/ping/ping -c5 -i0.02 dns.google
    ./builddir/ping/ping: sock4.fd: 3 (socktype: SOCK_DGRAM), sock6.fd: 4 (socktype: SOCK_DGRAM), hints.ai_family: AF_UNSPEC
    
    ai->ai_family: AF_INET, ai->ai_canonname: 'dns.google'
    PING dns.google (8.8.4.4) 56(84) bytes of data.
    64 bytes from dns.google (8.8.4.4): icmp_seq=1 ttl=117 time=15.1 ms
    64 bytes from dns.google (8.8.4.4): icmp_seq=2 ttl=117 time=22.9 ms
    64 bytes from dns.google (8.8.4.4): icmp_seq=3 ttl=117 time=19.3 ms
    64 bytes from dns.google (8.8.4.4): icmp_seq=4 ttl=117 time=20.0 ms
    64 bytes from 8.8.4.4: icmp_seq=5 ttl=117 time=21.4 ms

    $ ./builddir/ping/ping -c5 -i0.02 dns.google
    PING dns.google (8.8.8.8) 56(84) bytes of data.
    64 bytes from dns.google (8.8.8.8): icmp_seq=1 ttl=117 time=18.5 ms
    64 bytes from dns.google (8.8.8.8): icmp_seq=2 ttl=117 time=33.2 ms
    64 bytes from dns.google (8.8.8.8): icmp_seq=3 ttl=117 time=34.1 ms
    64 bytes from 8.8.8.8: icmp_seq=4 ttl=117 time=23.3 ms
    64 bytes from 8.8.8.8: icmp_seq=5 ttl=117 time=19.2 ms

Therefore revert commit 7c4049b698b04b71d97ec86daf1d02fd127360df and replace `{}` with proper form `{0}`.

Fixes: 7c4049b ("arping / ping: fix couple warnings")