### PR TITLE
add ret check of send_pack in arping

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -693,7 +693,7 @@ static void find_broadcast_address(struct run_state *ctl)
 
 static int event_loop(struct run_state *ctl)
 {
-	int exit_loop = 0, rc = 0;
+	int exit_loop = 0, rc = 0, err = 0;
 	ssize_t s;
 	enum {
 		POLLFD_SIGNAL = 0,
@@ -775,7 +775,7 @@ static int event_loop(struct run_state *ctl)
 	/* socket */
 	pfds[POLLFD_SOCKET].fd = ctl->socketfd;
 	pfds[POLLFD_SOCKET].events = POLLIN | POLLERR | POLLHUP;
-	send_pack(ctl);
+	err = send_pack(ctl);
 
 	while (!exit_loop) {
 		int ret;
@@ -818,7 +818,7 @@ static int event_loop(struct run_state *ctl)
 					exit_loop = 1;
 					continue;
 				}
-				send_pack(ctl);
+				err = send_pack(ctl);
 				break;
 			case POLLFD_TIMEOUT:
 				exit_loop = 1;
@@ -844,6 +844,8 @@ static int event_loop(struct run_state *ctl)
 	close(sfd);
 	close(tfd);
 	freeifaddrs(ctl->ifa0);
+	if (err < 0)
+                return err;
 	rc |= finish(ctl);
 	if (ctl->unsolicited)
 		/* nothing */;


### PR DESCRIPTION
In some special networking environments, like the beginning of bond4, sendto may fail. In that way, for example in arping, it will print Sent 0 probes output, but in most scenarios, we just judge the return value. In this cases it just returns -1, we wonder if it is necessary to add some more detailed error reportings in output ?

here is a issue about a usage of arping in this scene
https://github.com/fedora-sysv/initscripts/issues/465