### PR TITLE
Add `cap_net_admin`, refactor socket mark failure handling

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -357,7 +357,12 @@ xml:id="man.ping">
           <emphasis remap="I">mark</emphasis> to tag the packets
           going out. This is useful for variety of reasons within
           the kernel such as using policy routing to select
-          specific outbound processing.</para>
+          specific outbound processing. CAP_NET_ADMIN or CAP_NET_RAW
+          (since Linux 5.17) capability is required, see
+          <citerefentry>
+            <refentrytitle>socket</refentrytitle>
+            <manvolnum>7</manvolnum>
+          </citerefentry>.</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -828,8 +828,7 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		    setsockopt(probe_fd, IPPROTO_IP, IP_TOS, (char *)&rts->settos, sizeof(int)) < 0)
 			error(0, errno, _("warning: QOS sockopts"));
 
-		if (rts->opt_mark)
-			sock_setmark(rts->mark, probe_fd);
+		sock_setmark(rts, probe_fd);
 
 		dst.sin_port = htons(1025);
 		if (rts->nroute)

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -395,7 +395,7 @@ char *str_interval(int interval);
 int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);
 extern int pinger(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock);
 extern void sock_setbufs(struct ping_rts *rts, socket_st *, int alloc);
-extern void sock_setmark(unsigned int mark, int fd);
+extern void sock_setmark(struct ping_rts *rts, int fd);
 extern void setup(struct ping_rts *rts, socket_st *);
 extern int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st*,
 		     uint8_t *packet, int packlen);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -190,8 +190,7 @@ int ping6_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		    !IN6_IS_ADDR_MC_LINKLOCAL(&rts->firsthop.sin6_addr))
 			rts->firsthop.sin6_family = AF_INET6;
 
-		if (rts->opt_mark)
-			sock_setmark(rts->mark, probe_fd);
+		sock_setmark(rts, probe_fd);
 
 		rts->firsthop.sin6_port = htons(1025);
 		if (connect(probe_fd, (struct sockaddr *)&rts->firsthop, sizeof(rts->firsthop)) == -1) {


### PR DESCRIPTION
ping: Refactor socket mark failure handling

Ping warned 2x about setsockopt SO_MARK failure, because since 08f0e17 is called also for probe socket (before it was only on real socket):

	$ ping -m 2 ::1
	ping: WARNING: failed to set mark: 2: Operation not permitted
	PING ::1 (::1) 56 data bytes
	ping: WARNING: failed to set mark: 2: Operation not permitted
	64 bytes from ::1: icmp_seq=1 ttl=64 time=0.039 ms

Therefore pass rts struct to:

1) Disable SO_MARK call on real socket when it failed on probe socket,
therefore only single warning is printed.
2) Print hint about possible missing cap_net_admin+p capability

```
$ ./builddir/ping/ping -m 2 ::1
./builddir/ping/ping: WARNING: failed to set mark: 2: Operation not permitted
./builddir/ping/ping: => missing cap_net_admin+p capability?
PING ::1 (::1) 56 data bytes
64 bytes from ::1: icmp_seq=1 ttl=64 time=0.053 ms
```

Fixes: 08f0e17 ("ping: Set mark (SO_MARK) on probe socket")
Fixes: https://github.com/iputils/iputils/issues/515
