### PR TITLE
ping: Restore `-i0`

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -441,7 +441,7 @@ main(int argc, char **argv)
 			double optval;
 
 			optval = ping_strtod(optarg, _("bad timing interval"));
-			if (islessequal(optval, 0) || isgreater(optval, (double)INT_MAX / 1000))
+			if (isless(optval, 0) || isgreater(optval, (double)INT_MAX / 1000))
 				error(2, 0, _("bad timing interval: %s"), optarg);
 			rts.interval = (int)(optval * 1000);
 			rts.opt_interval = 1;


### PR DESCRIPTION
`-i 0` has been supported for a long time, restore it back. There is no point to force user to set very minimal value to emulate 0.

Found by LTP tests (nft01.sh, iptables01.sh) which use it.

Fixes: 2a63b94 ("ping: Fix overflow on negative -i")