### PR TITLE
feat(ping): ping support bind to device and addr at the same time

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -811,6 +811,9 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		argv++;
 	}
 
+	if (rts->device)
+		bind_to_device(rts, sock->fd, dst.sin_addr.s_addr);
+
 	if (rts->source.sin_addr.s_addr == 0) {
 		socklen_t alen;
 		int probe_fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -819,10 +822,8 @@ int ping4_run(struct ping_rts *rts, int argc, char **argv, struct addrinfo *ai,
 		if (probe_fd < 0)
 			error(2, errno, "socket");
 
-		if (rts->device) {
+		if (rts->device)
 			bind_to_device(rts, probe_fd, dst.sin_addr.s_addr);
-			bind_to_device(rts, sock->fd, dst.sin_addr.s_addr);
-		}
 
 		if (rts->settos &&
 		    setsockopt(probe_fd, IPPROTO_IP, IP_TOS, (char *)&rts->settos, sizeof(int)) < 0)


### PR DESCRIPTION
Currently, ping allows send packet from a specific address or a specificed interface but not both. With this PR,  one can use -I directive to  send ICMP packet through specific address and IP Address as below:

root@yatta:~/iputils/builddir/ping# ping 100.96.5.6 -I ipsecd9ykxy -I 100.96.5.5 -c 4
PING 100.96.5.6 (100.96.5.6) from 100.96.5.5 ipsecd9ykxy: 56(84) bytes of data.
64 bytes from 100.96.5.6: icmp_seq=1 ttl=64 time=0.017 ms
64 bytes from 100.96.5.6: icmp_seq=2 ttl=64 time=0.020 ms
64 bytes from 100.96.5.6: icmp_seq=3 ttl=64 time=0.027 ms
64 bytes from 100.96.5.6: icmp_seq=4 ttl=64 time=0.018 ms

--- 100.96.5.6 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 48ms
rtt min/avg/max/mdev = 0.017/0.020/0.027/0.006 ms 