### PR TITLE
Fix print time_t problem, when it runs on 32 bits platform.

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -903,7 +903,7 @@ int finish(struct ping_rts *rts)
 #endif
 		printf(_(", %g%% packet loss"),
 		       (float)((((long long)(rts->ntransmitted - rts->nreceived)) * 100.0) / rts->ntransmitted));
-		printf(_(", time %ldms"), 1000 * tv.tv_sec + (tv.tv_nsec + 500000) / 1000000);
+		printf(_(", time %llums"), (unsigned long long)(1000 * tv.tv_sec + (tv.tv_nsec + 500000) / 1000000));
 	}
 
 	putchar('\n');


### PR DESCRIPTION
- We have an image compiled with musl libc, which have configured time_t as 64-bit.
_musl 1.2.0 changes the definition of time_t, and thereby the definitions of all derived types, to be 64-bit across all archs._

- We have this image run on a 32-bit platform, then we encountered a problem. The consumed time for ping is always shown as 0ms in the output.
<pre>
ping 172.16.0.9
PING 172.16.0.9 (172.16.0.9) 56(84) bytes of data.
64 bytes from 172.16.0.9: icmp_seq=1 ttl=64 time=0.745 ms
64 bytes from 172.16.0.9: icmp_seq=2 ttl=64 time=0.914 ms
64 bytes from 172.16.0.9: icmp_seq=3 ttl=64 time=0.930 ms
--- 172.16.0.9 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.745/0.863/0.930/0.083 ms
</pre>
- I think a casting is necessary here.  From musl time64 Release Notes
<pre>
Undefined behavior and unwarranted assumptions
    Use of %ld format to print time_t or suseconds_t.
</pre>