### PR TITLE
ping: fix IPv4 checksum check always succeeding once again

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1654,7 +1654,7 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 			wrong_source = 1;
 		if (gather_statistics(rts, (uint8_t *)icp, sizeof(*icp), cc,
 				      ntohs(icp->un.echo.sequence),
-				      reply_ttl, 0, tv, pr_addr(rts, from, sizeof *from),
+				      reply_ttl, csfailed, tv, pr_addr(rts, from, sizeof *from),
 				      pr_echo_reply, rts->multicast, wrong_source)) {
 			fflush(stdout);
 			return 0;


### PR DESCRIPTION
This issue was fixed once already in commit bff65fbb6f73 ("fix checksum always success in IPv4 ping."), but was reverted shortly after, likely due to a botched rebase.

Fix this issue again, so ping correctly reports checksum mismatches in ICMP ECHO replies.

Fixes: 8b8686794f69 ("warnings: remove variable shadowing")

---

To reproduce: Boot [barebox](https://www.barebox.org/doc/latest/boards/bcm2835.html#raspberry-pi) v2024.03.0 or older on a Raspberry Pi 3b and ping its network interface. Without [recent fixes](https://lore.barebox.org/barebox/20240404184001.1532897-1-a.fatoum@pengutronix.de/T/#mc182a3fe4eb2053a9af13e5a5e15c830a5ef468d), this results in checksum mismatch as reported by Wireshark. With this patch applied, `ping(1)` will also report this checksum mismatch:

```
64 bytes from 192.168.10.82: icmp_seq=1 ident=1066 ttl=64 time=9.69 ms (BAD CHECKSUM!)
```