### PR TITLE
arping: optimize 1s loop delay for unsolicited ARP + fix regression 4db1de6

### DIFF
--- a/arping.c
+++ b/arping.c
@@ -776,9 +776,14 @@ static int event_loop(struct run_state *ctl)
 	pfds[POLLFD_SOCKET].events = POLLIN | POLLERR | POLLHUP;
 	send_pack(ctl);
 
-	while (!(exit_loop || ctl->unsolicited)) {
+	while (!exit_loop) {
 		int ret;
 		size_t i;
+
+		if ((ctl->sent == ctl->count) && ctl->unsolicited) {
+			exit_loop = 1;
+			continue;
+		}
 
 		ret = poll(pfds, POLLFD_COUNT, -1);
 		if (ret <= 0) {
@@ -840,6 +845,7 @@ static int event_loop(struct run_state *ctl)
 			}
 		}
 	}
+
 	close(sfd);
 	close(tfd);
 	freeifaddrs(ctl->ifa0);


### PR DESCRIPTION
https://github.com/iputils/iputils/commit/4db1de672559804bebcb7073d231924339ca8cd8 tried to fix a regression 1 sec delay due poll() for unsolicited ARP, .i.e. -A and -U (introduced in https://github.com/iputils/iputils/commit/67e070d08dcbec990e1178360f82b3e2ca4f6d5f, reported as issue https://github.com/iputils/iputils/issues/536). But skipping the while loop entirely introduced another regression for `-A` and `-U`, which behave like `-c1` (sending *always* only a single packet).

Fixing it by checking in while loop and comparing also count (as it was done in https://github.com/iputils/iputils/commit/67e070d08dcbec990e1178360f82b3e2ca4f6d5f before the rewrite).

Fixes: 4db1de6 ("arping: Fix 1s delay on exit for unsolicited arpings")
Fixes: https://github.com/iputils/iputils/commit/67e070d08dcbec990e1178360f82b3e2ca4f6d5f ("arping: use signalfd() and timerfd() rather than signals")
Fixes: https://github.com/iputils/iputils/issues/536
Reported-by: David Bond <dbond@suse.com>