### PR TITLE
ping: check return value of write() to avoid integer overflow

### DIFF
--- a/ping/ping.h
+++ b/ping/ping.h
@@ -290,8 +290,12 @@ static inline void write_stdout(const char *str, size_t len)
 	ssize_t cc;
 	do {
 		cc = write(STDOUT_FILENO, str + o, len - o);
-		o += cc;
-	} while (len > o || cc < 0);
+
+		if (cc < 0)
+			break;
+
+		o += (size_t) cc;
+	} while (len > o);
 }
 
 /*


### PR DESCRIPTION
The problem was discovered by the Coverity static analysis tool.

```c
Error: INTEGER_OVERFLOW (CWE-190):
iputils-20240117/ping/ping.h:291: tainted_data_return: Called function "write(1, str + o, len - o)", and a possible return value may be less than zero. 
iputils-20240117/ping/ping.h:291: assign: Assigning: "cc" = "write(1, str + o, len - o)". 
iputils-20240117/ping/ping.h:292: overflow: The expression "o += cc" might be negative, but is used in a context that treats it as unsigned. 
iputils-20240117/ping/ping.h:291: overflow: The expression "len - o" is deemed underflowed because at least one of its arguments has underflowed. 
iputils-20240117/ping/ping.h:291: overflow_sink: "len - o", which might have underflowed, is passed to "write(1, str + o, len - o)".
#  289|           ssize_t cc;
#  290|           do {
#  291|->                 cc = write(STDOUT_FILENO, str + o, len - o);
#  292|                   o += cc;
#  293|           } while (len > o || cc < 0);
```