### PR TITLE
ci: Remove Centos 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,6 @@ jobs:
             env:
               CC: gcc
 
-          - container: "centos:7"
-            env:
-              CC: gcc
-
           - container: "debian:testing"
             env:
               CC: gcc


### PR DESCRIPTION
Centos 7 is EOL since 2024-06. Therefore CI build fails with:

```
Could not resolve host: mirrorlist.centos.org; Unknown error
```
@robert-scheck Can you please review?