### PR TITLE
ping: Allow to disable with environment variable

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -288,7 +288,10 @@ xml:id="man.ping">
         <listitem>
           <para>Force DNS name resolution for the output. Useful for numeric
           destination, or <option>-f</option> option, which by default do not
-          perform it. Override previously defined <option>-n</option> option.
+          perform it. It can also help to workaround DNS resolution problems.
+          Override previously defined <option>-n</option> option.
+          See also <emphasis remap="I">IPUTILS_PING_PTR_LOOKUP</emphasis>
+          environment variable.
           </para>
         </listitem>
       </varlistentry>
@@ -552,6 +555,8 @@ xml:id="man.ping">
           symbolic names for host addresses (no reverse DNS resolution).
           This is the default for numeric destination or <option>-f</option>
           option.  Override previously defined <option>-H</option> option.
+          See also <emphasis remap="I">IPUTILS_PING_PTR_LOOKUP</emphasis>
+          environment variable.
           </para>
         </listitem>
       </varlistentry>
@@ -779,6 +784,15 @@ xml:id="man.ping">
     on the network, it is unwise to use
     <command>ping</command> during normal operations or from
     automated scripts.</para>
+  </refsection>
+
+  <refsection xml:id="environment">
+    <info>
+      <title>ENVIRONMENT</title>
+    </info>
+	<emphasis remap="I">IPUTILS_PING_PTR_LOOKUP</emphasis> environment
+	variable set to 0 disable reverse DNS resolution (PTR lookup) by default.
+	It will be overrided by <option>-H</option> or <option>-n</option> option.
   </refsection>
 
   <refsection xml:id="exit_status">

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -378,6 +378,17 @@ main(int argc, char **argv)
 	else if (argv[0][strlen(argv[0]) - 1] == '6')
 		hints.ai_family = AF_INET6;
 
+	/*
+	 * Optionally disable reverse DNS resolution (PTR lookup) by default.
+	 * -n/-H override the variable. Warn below if disabled due this.
+	 */
+	char *env = getenv("IPUTILS_PING_PTR_LOOKUP");
+	int force_numeric = 0;
+	if (env && !strcmp(env, "0")) {
+		rts.opt_numeric = 1;
+		force_numeric = 1;
+	}
+
 	/* Parse command line options */
 	while ((ch = getopt(argc, argv, "h?" "4bRT:" "6F:N:" "3aABc:CdDe:fHi:I:l:Lm:M:nOp:qQ:rs:S:t:UvVw:W:")) != EOF) {
 		switch(ch) {
@@ -583,6 +594,9 @@ main(int argc, char **argv)
 			break;
 		}
 	}
+
+	if (rts.opt_numeric && force_numeric && !rts.opt_quiet)
+		error(0, 0, _("WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"));
 
 	argc -= optind;
 	argv += optind;


### PR DESCRIPTION
Allow to disable reverse DNS resolution (PTR lookup) with IPUTILS_PING_PTR_LOOKUP environment variable set to 0:

    $ IPUTILS_PING_PTR_LOOKUP=0 ./builddir/ping/ping -c1 google.com
    PING google.com (142.251.37.110) 56(84) bytes of data.
    64 bytes from 142.251.37.110: icmp_seq=1 ttl=116 time=11.1 ms

It's off by default:

    $ ./builddir/ping/ping -c1 google.com
    PING google.com (142.251.37.110) 56(84) bytes of data.
    64 bytes from prg03s13-in-f14.1e100.net (142.251.37.110): icmp_seq=1 ttl=116 time=18.6 ms

`-H/-n` override the variable:

    $ IPUTILS_PING_PTR_LOOKUP=0 ./builddir/ping/ping -c1 -H google.com
    PING google.com (142.251.37.110) 56(84) bytes of data.
    64 bytes from prg03s13-in-f14.1e100.net (142.251.37.110): icmp_seq=1 ttl=116 time=17.1 ms

    $ IPUTILS_PING_PTR_LOOKUP= ./builddir/ping/ping -c1 -n google.com
    PING google.com (142.251.37.110) 56(84) bytes of data.
    64 bytes from 142.251.36.142: icmp_seq=1 ttl=116 time=15.8 ms

Update man page.

NOTE: variable needs to be parsed before getopts, therefore the optional warning is printed afterwards (only if the lookup disabled due environment variable and if not `-q`).

Implements: https://github.com/iputils/iputils/issues/531