### PR TITLE
ping: support IPv4-Mapped-in-IPv6 target addresses

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -353,6 +353,7 @@ main(int argc, char **argv)
 		.ni.subject_type = -1,
 	};
 	unsigned char buf[sizeof(struct in6_addr)];
+	struct in6_addr a6;
 
 	/* FIXME: global_rts will be removed in future */
 	global_rts = &rts;
@@ -618,6 +619,15 @@ main(int argc, char **argv)
 			error(0, 0, _("WARNING: ident 0 => forcing raw socket"));
 
 		hints.ai_socktype = SOCK_RAW;
+	}
+
+	if (inet_pton(AF_INET6, target, &a6)) {
+		if (IN6_IS_ADDR_V4MAPPED(&a6)) {
+			target = strrchr(target, ':') + 1;
+			hints.ai_family = AF_INET;
+			if (rts.opt_verbose)
+				printf("IPv4-Mapped-in-IPv6 address; using IPv4 %s\n", target);
+		}
 	}
 
 	if (hints.ai_family != AF_INET6) {


### PR DESCRIPTION
Additional feature:

Addresses of the form `::ffff:127.0.0.1` would be treated as IPv6 but should be converted to IPv4 and handled as such.
```
iputils$ build/ping/ping -n -v ::ffff:127.0.0.1
IPv4-Mapped-in-IPv6 address; using IPv4 127.0.0.1
build/ping/ping: sock4.fd: 3 (socktype: SOCK_RAW), sock6.fd: -1 (socktype: 0), hints.ai_family: AF_INET

ai->ai_family: AF_INET, ai->ai_canonname: '127.0.0.1'
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ident=45999 ttl=64 time=0.032 ms
64 bytes from 127.0.0.1: icmp_seq=2 ident=45999 ttl=64 time=0.053 ms
64 bytes from 127.0.0.1: icmp_seq=3 ident=45999 ttl=64 time=0.054 ms
^C
--- 127.0.0.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2039ms
rtt min/avg/max/mdev = 0.032/0.046/0.054/0.010 ms
```