### PR TITLE
Handle hex-encoded IPv4-Mapped-in-IPv6 addresses

### DIFF
--- a/test/ping/meson.build
+++ b/test/ping/meson.build
@@ -6,10 +6,18 @@
 # https://github.com/actions/virtual-environments/issues/668
 ipv6_dst = []
 ipv6_switch = []
+ipv4_in_ipv6_dot_dst = []
+ipv4_in_ipv6_hex_dst_0 = []
+ipv4_in_ipv6_hex_dst_1 = []
+ipv4_in_ipv6_hex_dst_2 = []
 ip = find_program('ip', required: false)
 if ip.found() and run_command(ip, '-6', 'a').stdout().contains('::1')
   message('IPv6 enabled')
   ipv6_dst = [ '::1' ]
+  ipv4_in_ipv6_dot_dst = [ '::ffff:127.0.0.1' ]
+  ipv4_in_ipv6_hex_dst_0 = [ '::ffff:7f00:1' ]
+  ipv4_in_ipv6_hex_dst_1 = [ '0:0::ffff:7f00:1' ]
+  ipv4_in_ipv6_hex_dst_2 = [ '::0:0:ffff:7f00:1' ]
   ipv6_switch = [ '-6' ]
 elif not ip.found()
   message('WARNING: ip binary not found => disable IPv6 tests')
@@ -33,7 +41,7 @@ args = ['-V']
 name = 'ping ' + ' '.join(args)
 test(name, ping, args : args)
 
-foreach dst : [ 'localhost', '127.0.0.1' ] + ipv6_dst
+foreach dst : [ 'localhost', '127.0.0.1' ] + ipv6_dst + ipv4_in_ipv6_dot_dst + ipv4_in_ipv6_hex_dst_0 + ipv4_in_ipv6_hex_dst_1 + ipv4_in_ipv6_hex_dst_2
   foreach switch : [ '', '-4' ] + ipv6_switch
 	args = [ '-c1', dst ]
 	should_fail = false
@@ -58,7 +66,7 @@ ping_tests_opt = [
   [ '-c1', '-W1' ],
   [ '-c1', '-W1.1' ],
 ]
-foreach dst : [ '127.0.0.1' ] + ipv6_dst
+foreach dst : [ '127.0.0.1' ] + ipv6_dst + ipv4_in_ipv6_dot_dst + ipv4_in_ipv6_hex_dst_0 + ipv4_in_ipv6_hex_dst_1 + ipv4_in_ipv6_hex_dst_2
   foreach args : ping_tests_opt
 	args += [ dst ]
 	name = cmd_name + ' '.join(args)
@@ -72,7 +80,7 @@ ping_tests_opt_fail = [
   [ '-w0.1' ],
   [ '-w0,1' ],
 ]
-foreach dst : [ '127.0.0.1' ] + ipv6_dst
+foreach dst : [ '127.0.0.1' ] + ipv6_dst + ipv4_in_ipv6_dot_dst + ipv4_in_ipv6_hex_dst_0 + ipv4_in_ipv6_hex_dst_1 + ipv4_in_ipv6_hex_dst_2
   foreach args : ping_tests_opt_fail
 	args += [ dst ]
 	name = cmd_name + ' '.join(args)
@@ -83,7 +91,7 @@ endforeach
 ping_tests_user_fail = [
   [ '-c1', '-i0.001' ], # -c1 required to quit ping when running as root
 ]
-foreach dst : [ '127.0.0.1' ] + ipv6_dst
+foreach dst : [ '127.0.0.1' ] + ipv6_dst + ipv4_in_ipv6_dot_dst + ipv4_in_ipv6_hex_dst_0 + ipv4_in_ipv6_hex_dst_1 + ipv4_in_ipv6_hex_dst_2
   foreach args : ping_tests_user_fail
 	args += [ dst ]
 	name = cmd_name + ' '.join(args)


### PR DESCRIPTION
Hexadecimal encoding such as `::ffff:7f:1`  would break IPv4 handling; the hex value needs converting to dotted decimal.

I've also added tests (I think correctly!) for both.