### PR TITLE
ping ipv4 addresses masked as ipv6 after resolving hostname etc

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -722,9 +722,6 @@ main(int argc, char **argv)
 			break;
 		case AF_INET6:
 			if( SA6_IS_ADDR_V4MAPPED( ai->ai_addr ) ) { // if ipv6 is actually a masked ipv4 address
-				if (rts.opt_verbose)
-					error(0, 0, _("IPv4-Mapped-in-IPv6 address, using IPv4 %s"), target);
-
 				// compose an ipv4 addressinfo record valid *only* for a call to ping4_run:
 				struct sockaddr_in sa4;
 				memset( &sa4, 0, sizeof( struct sockaddr_in ) );   // optional: zero out this sockaddr_in
@@ -733,6 +730,13 @@ main(int argc, char **argv)
 				const int IPV4_OFFSET_IN_IPV6 = sizeof( struct in6_addr ) - sizeof( struct in_addr ); // 12
 				// copy ipv4 part of ipv6 into ipv4 record:
 				memcpy( &sa4.sin_addr, ( ( char * ) &( (struct sockaddr_in6 * ) ai->ai_addr)->sin6_addr ) + IPV4_OFFSET_IN_IPV6, sizeof( struct in_addr ) );
+
+				if (rts.opt_verbose) {
+					char strIpv4[ 16 ]; // max len of an ipv4 address in decimal representation: 16 == 4 times 3 digits + 3 dots + terminating zero-byte
+					unsigned char * ipBytes = ( unsigned char * ) &sa4.sin_addr;
+					snprintf ( strIpv4, sizeof( strIpv4 ), "%u.%u.%u.%u", ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3] );
+					error(0, 0, _("IPv4-Mapped-in-IPv6 address, using IPv4 %s (%s)"), strIpv4, target);
+				}
 
 				struct addrinfo ai4;
 				ai4.ai_flags = 0;                // TBD by someone smarter than me: does this matter for ping?


### PR DESCRIPTION
Regarding https://github.com/iputils/iputils/pull/558 and https://github.com/iputils/iputils/pull/561, as the original "complainer" ;), I would like to propose a different solution to support for pinging ipv4 addresses masked in an ipv6 - in this pull request I do so by detecting an ipv4 *after* the call to getaddrinfo, thus allowing hostname resolution and even if that returns an ipv4 masked in ipv6, create a proper ipv4 addrinfo entry to call ping4_run on.

Lars Uffmann <coding23@uffmann.name>

**PS:** Someone smarter than me (see comments ;) should review the values assigned to the addrinfo struct that I believe do not matter for the purpose of the ping tool. Accordingly - remove my comments.
Also, feel free to move my ```SA6_IS_ADDR_V4MAPPED``` macro into the code proper.

PPS: For the verbose output, I did not modify the target string, because it *could* be a hostname in my implementation, so that the verbose output looks like so:
```
build/ping/ping: IPv4-Mapped-in-IPv6 address, using IPv4 ::ffff:7f00:1
```
or like so:
```
build/ping/ping: IPv4-Mapped-in-IPv6 address, using IPv4 hostname
```
927a2ec111791e4a9b220a529893e3cfcd523f3b addresses this with an snprintf of the resolved ipv4.

PPPS: This pull request does not add the tests that @iam-TJ added in https://github.com/iputils/iputils/pull/561