### PR TITLE
Revert "ping: support IPv4-Mapped-in-IPv6 target addresses"

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -353,7 +353,6 @@ main(int argc, char **argv)
 		.ni.subject_type = -1,
 	};
 	unsigned char buf[sizeof(struct in6_addr)];
-	struct in6_addr a6;
 
 	/* FIXME: global_rts will be removed in future */
 	global_rts = &rts;
@@ -619,14 +618,6 @@ main(int argc, char **argv)
 			error(0, 0, _("WARNING: ident 0 => forcing raw socket"));
 
 		hints.ai_socktype = SOCK_RAW;
-	}
-
-	if (inet_pton(AF_INET6, target, &a6) && IN6_IS_ADDR_V4MAPPED(&a6)) {
-			target = strrchr(target, ':') + 1;
-			hints.ai_family = AF_INET;
-
-			if (rts.opt_verbose)
-				error(0, 0, _("IPv4-Mapped-in-IPv6 address, using IPv4 %s"), target);
 	}
 
 	if (hints.ai_family != AF_INET6) {

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-28 15:00+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech <https://translate.fedoraproject.org/projects/iputils/"
@@ -146,9 +146,9 @@ msgstr "Rozhraní „%s“ nepodporuje protokol ARP\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "POZOR: používá se výchozí všesměrová adresa.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "neplatný argument"
@@ -290,7 +290,7 @@ msgid "too long scope name"
 msgstr "název síťové oblasti je příliš dlouhý"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "nepodařilo se přidělit paměť"
 
@@ -344,7 +344,7 @@ msgstr ""
 "  subject-name=jméno\n"
 "  subject-fqdn=jméno\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "neznámé rozhraní: %s"
@@ -353,7 +353,7 @@ msgstr "neznámé rozhraní: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "nejednotnost síťové oblasti mezi uzly"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "Pozor: zdrojová adresa může být vybrána na zařízením jiném než: %s"
@@ -399,7 +399,7 @@ msgstr "jmenovku toku nelze nastavit"
 msgid "can't send flowinfo"
 msgstr "údaje o toku nelze poslat"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -409,7 +409,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", tok 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "od %s %s: "
@@ -554,7 +554,7 @@ msgstr "Zkrácení MLD"
 msgid "unknown icmp type: %u"
 msgstr "neznámý typ ICMP: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "místní chyba"
 
@@ -563,12 +563,12 @@ msgstr "místní chyba"
 msgid "local error: message too long, mtu: %u"
 msgstr "místní chyba: zpráva je příliš dlouhá, MTU: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "Od %s pořadí=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " pořadí=%u"
@@ -623,16 +623,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "paket je příliš krátký: %d bajtů"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "Od %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "POZOR: soketový filtr se nepodařilo nainstalovat"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "neznámá generace protokolu: %d"
@@ -675,76 +675,71 @@ msgstr "chybná hodnota ToS: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "je třeba, aby desítková hodnota bitů ToS byla z rozsahu 0 až 255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "není možné použít souběžně oba přepínače -4 a -6"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "není možné použít souběžně oba přepínače -T a -R"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "neplatný druh časové značky: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "chybný časový interval"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "chybný časový interval: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "nelze zkopírovat: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "neplatná zdrojová adresa: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "hodnotu přednačítání nelze nastavit na více jak 3: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "neplatný argument -M: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "chybný čas čekání"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "chybný čas čekání: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr "POZOR: reverzní vyhledávání DNS (PTR záznam) vypnuto, vynutit s -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "POZOR: ident 0 => vyžadován raw socket"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "Adresa IPv4 namapováno v IPv6 adrese, s použitím IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "neplatná hodnota -s: „%d“: mimo rozsah: 0 <= hodnota <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -753,11 +748,11 @@ msgstr ""
 "Pozor: IPv6 link-local adresa u ICMP datagram socketu může vyžadovat ifname "
 "nebo scope-id => použijte: adresa%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "pozor: QoS volby soketu"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -765,20 +760,20 @@ msgstr ""
 "Přejete si všesměrový ping? Pak použijte -b. Pokud ne, zkontrolujte pravidla "
 "místní brány firewall"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "POZOR: jedná se o ping na adresu všesměrového vysílání\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "všesměr nelze nastavit"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "funkce getifaddrs nezafungovala"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -787,46 +782,46 @@ msgstr ""
 "Minimální interval pro všesměrový ping pro uživatele musí být >=%d ms, "
 "použijte -i%s (nebo vyšší)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "všesměrový ping se nefragmentuje"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "POZOR: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr ""
 "POZOR: jádro vámi používaného systému je ale opravdu staré verze. Nicméně "
 "zatím žádné problémy."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "POZOR: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "POZOR: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "příjem vlastních multicastových dotazů nelze zakázat"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "délku životnosti nelze u multicastu nastavit"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "délku životnosti nelze u unicastu nastavit"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d (%d) datových bajtů.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -835,7 +830,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -844,12 +839,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(stejná trasa)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -858,7 +853,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -867,27 +862,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absolutní, nestandardní"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld nestandardní"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absolutní"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Nezaznamenané skoky: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -896,232 +891,232 @@ msgstr ""
 "\n"
 "neznámá volba %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL ToS  Dél   ID Pří  vyp TTL Pro  ksč      Zdr      Cíl Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Odpověď na echo\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Cílová síť nedostupná\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Cílový stroj nedostupný\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Cílový protokol nedostupný\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Cílový port nedostupný\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Potřeba fragmentace, ale DF je nastaveno (MTU = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Zdrojová trasa nezafungovala\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Cílová síť není známa\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Cílový stroj není znám\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Zdrojový stroj je izolován\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Cílová síť je zakázána\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Cílový stroj je zakázán\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Cílový síť není pro daný typ služby dostupná\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Cílový stroj není pro daný typ služby dostupný\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paket odfiltrován\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Porušuje přednost\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Nedostatečná přednost\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Cíl nedostupný, chybný kód: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Útlum zdroje\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Přesměrování sítě"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Přesměrování stroje"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Přesměrování druhu služby a sítě"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Přesměrování druhu služby a stroje"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Přesměrování, chybný kód: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Nový následující skok: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Požadavek na echo\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Překročena doba životnosti\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Překročena doba pro provedení opětovného složení fragmentů\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Překročen čas, chybný kód: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Problém s parametrem: ukazatel = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Časová značka\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Odpověď s časovou značkou\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Dotaz na informace\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Odpověď s informacemi\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Dotaz na masku adresy\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Odpověď s maskou adresy\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Chybný typ ICMP: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "místní chyba: zpráva je příliš dlouhá, MTU=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "paket od %s je příliš krátký (%d bajtů)"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "Od %s: pořadí=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(CHYBNÝ KONTROLNÍ SOUČET)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(CHYBNÝ KONTROLNÍ SOUČET)\n"
@@ -1208,8 +1203,8 @@ msgstr ""
 "identifikátor 0)\n"
 "  -f                   zahlcující ping\n"
 "  -h                   vypíše tuto nápovědu a skončí\n"
-"  -H                   vynutí překlad reverzního DNS doménového jména ("
-"vhodné pro numerické\n"
+"  -H                   vynutí překlad reverzního DNS doménového jména "
+"(vhodné pro numerické\n"
 "                       cíle nebo pro -f), přebije -n\n"
 "  -I <rozhraní>        rozhraní nebo adresa\n"
 "  -i <interval>        interval v sekundách mezi posíláním jednotlivých "
@@ -1217,8 +1212,8 @@ msgstr ""
 "  -L                   potlačí příjem vlastních multicastových dotazů\n"
 "  -l <přednačítání>    pošle <přednačítání> paketů během čekání na odpovědi\n"
 "  -m <značka>          označí odchozí pakety\n"
-"  -M <pmtud volba>     definuje volbu pro PMTU discovery, jedno z "
-"<do|dont|want|probe>\n"
+"  -M <pmtud volba>     definuje volbu pro PMTU discovery, jedno z <do|dont|"
+"want|probe>\n"
 "  -n                   nepřeloží doménová jména, přebije -H\n"
 "  -O                   nahlásí nevyřízené odpovědi\n"
 "  -p <vzor>            nastaví obsah výplňového bitu\n"
@@ -1238,8 +1233,8 @@ msgstr ""
 "  -4                   použije IPv4\n"
 "  -b                   povolí všesměrový ping\n"
 "  -R                   zaznamenat směrování\n"
-"  -T <časová značka>   definuje časovou značku, jedno z "
-"<tsonly|tsandaddr|tsprespec>\n"
+"  -T <časová značka>   definuje časovou značku, jedno z <tsonly|tsandaddr|"
+"tsprespec>\n"
 "\n"
 "IPv6 volby:\n"
 "  -6                   použije IPv6\n"
@@ -1569,6 +1564,10 @@ msgstr "zpět %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "Je třeba, aby délka paketu byla z rozmezí: %d < hodnota <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "Adresa IPv4 namapováno v IPv6 adrese, s použitím IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-11-04 17:56+0000\n"
 "Last-Translator: Marek Küthe <m.k@mk16.de>\n"
 "Language-Team: German <https://translate.fedoraproject.org/projects/iputils/"
@@ -147,9 +147,9 @@ msgstr "Schnittstelle „%s“ ist nicht ARPfähig\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "WARNUNG: Nutze Standard-Broadcastadresse.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "ungültiges Argument"
@@ -294,7 +294,7 @@ msgid "too long scope name"
 msgstr "zu langer Bereichsname"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "Speicherzuweisung ist gescheitert"
 
@@ -348,7 +348,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "unbekannte Schnittstelle: %s"
@@ -357,7 +357,7 @@ msgstr "unbekannte Schnittstelle: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "Bereichsunstimmigkeit unter den Knoten"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -405,7 +405,7 @@ msgstr "kann Flowlabel nicht setzen"
 msgid "can't send flowinfo"
 msgstr "kann Flussinfo nicht senden"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -415,7 +415,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", flow 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "von %s %s: "
@@ -560,7 +560,7 @@ msgstr "MLD-Reduktion"
 msgid "unknown icmp type: %u"
 msgstr "unbekannter icmp-Typ: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "lokaler Fehler"
 
@@ -569,12 +569,12 @@ msgstr "lokaler Fehler"
 msgid "local error: message too long, mtu: %u"
 msgstr "lokaler Fehler: Nachricht zu lang, MTU: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "Von %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -629,16 +629,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "Paket zu klein:%d Bytes"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "Von %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "WARNUNG: Socket-Filter konnte nicht installiert werden"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "unbekannte Protokollfamilie: %d"
@@ -681,77 +681,72 @@ msgstr "falscher TOS-Wert: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "der Dezimalwert der TOS-Bits muss im Bereich 0-255 liegen: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "Es kann nur eine -4- oder -6-Option angegeben werden"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "Es kann nur -T oder -R genutzt werden"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "ungültiger Zeitstempel-Typ: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "schlechtes Zeitintervall"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "schlechtes Zeitintervall: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "kann nicht kopieren: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "ungültige Quell-Adresse: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "kann preload nicht auf Wert größer als 3 setzen: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "ungültiger -M Parameter: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "schlechte Verweildauer"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "schlechte Verweildauer: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "WARNUNG: Umgekehrte DNS-Auflösung (PTR-Lookup) deaktiviert, mit -H erzwingen"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "WARNING: ident 0 => erzwinge raw socket"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "In IPv6 eingebettete IPv4-Adresse, verwende IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "ungültiger -s Wert: '%d': außerhalb des Bereiches: 0 <= Wert <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -760,11 +755,11 @@ msgstr ""
 "Warnung: IPv6 link-local Adresse auf einem ICMP Datagrammsockel kann ifname "
 "or Bereichs-ID erfordern => benutzen Sie: Adresse%%<ifname|Bereichs-ID>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "Warnung: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -772,20 +767,20 @@ msgstr ""
 "Möchten Sie broadcast pingen? Dann -b. Falls nicht, überprüfen Sie die "
 "lokalen Firewall Richtlinien"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "WARNUNG: Pinge Broadcast-Adresse\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "kann broadcasting nicht einstellen"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs fehlgeschlagen"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -794,44 +789,44 @@ msgstr ""
 "Mindestintervall für Broadcast-Ping für Benutzer, muss >= %d ms sein, "
 "benutze -i %s (or höher)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "Broadcast Ping fragmentiert nicht"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "WARNUNG: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "WARNING: Ihr Kernel ist seeehr alt. Keine Probleme."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "WARNUNG: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "WARNUNG: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "kann Multicast-Loopback nicht deaktivieren"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "kann Multicast TTL nicht einstellen"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "kann Unicast TTL nicht einstellen"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) Bytes an Daten.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -840,7 +835,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -849,12 +844,12 @@ msgstr ""
 "\n"
 "%cSSR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(gleiche Route)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -863,7 +858,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -872,27 +867,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absolut nicht standardisiert"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld nicht standardisiert"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absolut"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Nicht aufgezeichnete Hops: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -901,232 +896,232 @@ msgstr ""
 "\n"
 "unbekannte Option %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Echo-Antwort\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Zielnetz nicht erreichbar\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Zielhost nicht erreichbar\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Zielprotokoll nicht erreichbar\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Zielport nicht erreichbar\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Fragmentierung benötigt und DF gesetzt (mtu=%u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Fehler bei Quellroute\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Zielnetz unbekannt\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Zielhost unbekannt\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Quellhost isoliert\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Zielnetz verboten\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Zielhost verboten\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Zielnetz unerreichbar für Typ des Dienstes\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Zielhost unerreichbar für Typ des Dienstes\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paket gefiltert\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Vorrangsverletzung\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Vorrang Cutoff\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Ziel nicht erreichbar, Fehlercode: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Quellenlöschung\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Netzwerk umleiten"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Host umleiten"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Leite Typ des Dienstes und Netzwerk um"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Leite Typ des Dienstes und Host um"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Leite um, Fehlercode: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Neuer Nexthop: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Echo-Anforderung\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Lebenszeit überschritten\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Fragmentierungs-Wiederherstellungszeit überschritten\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Zeit überschritten, schlechter Code: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Parameterproblem: Zeiger = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Zeitstempel\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Zeitstempel-Antwort\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Informationsanfrage\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Informationsantwort\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Adressmaske-Anfrage\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Adressmaske-Antwort\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Falscher ICMP-Typ: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "lokaler Fehler: Nachricht zu lang, MTU=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "Paket zu kurz (%d Bytes) aus %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "Von %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(FALSCHE PRÜFSUMME)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(FALSCHE PRÜFSUMME)\n"
@@ -1573,6 +1568,10 @@ msgstr "zurück %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen muss innerhalb von %d < Wert <= %d liegen"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "In IPv6 eingebettete IPv4-Adresse, verwende IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-11-10 02:02+0000\n"
 "Last-Translator: Emilio Herrera <ehespinosa57@gmail.com>\n"
 "Language-Team: Spanish <https://translate.fedoraproject.org/projects/iputils/"
@@ -53,8 +53,8 @@ msgstr ""
 "  -V            imprime la versión y sale\n"
 "  -c <count>    cuántos paquetes enviar\n"
 "  -w <timeout>  cuánto esperar una respuesta\n"
-"  -i <interval> fijar el intervalo entre paquetes (predeterminado: 1 segundo)"
-"\n"
+"  -i <interval> fijar el intervalo entre paquetes (predeterminado: 1 "
+"segundo)\n"
 "  -I <device>   que dispositivo ethernet utilizar"
 
 #: arping.c:142
@@ -148,9 +148,9 @@ msgstr ""
 msgid "WARNING: using default broadcast address.\n"
 msgstr ""
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr ""
@@ -273,7 +273,7 @@ msgid "too long scope name"
 msgstr ""
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgid ""
 "  subject-fqdn=name\n"
 msgstr ""
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "scope discrepancy among the nodes"
 msgstr ""
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -362,7 +362,7 @@ msgstr ""
 msgid "can't send flowinfo"
 msgstr ""
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr ""
@@ -372,7 +372,7 @@ msgstr ""
 msgid ", flow 0x%05x, "
 msgstr ""
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr ""
@@ -517,7 +517,7 @@ msgstr ""
 msgid "unknown icmp type: %u"
 msgstr ""
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgstr ""
 msgid "local error: message too long, mtu: %u"
 msgstr ""
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr ""
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr ""
@@ -586,16 +586,16 @@ msgstr ""
 msgid "packet too short: %d bytes"
 msgstr ""
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr ""
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr ""
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr ""
@@ -638,435 +638,430 @@ msgstr ""
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr ""
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr ""
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr ""
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr ""
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr ""
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr ""
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr ""
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr ""
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr ""
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr ""
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr ""
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr ""
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr ""
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
 "or scope-id => use: address%%<ifname|scope-id>"
 msgstr ""
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr ""
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
 msgstr ""
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr ""
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr ""
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr ""
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr ""
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr ""
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr ""
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr ""
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr ""
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr ""
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr ""
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr ""
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
 "NOP"
 msgstr ""
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
 "%cSRR: "
 msgstr ""
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr ""
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
 "RR: "
 msgstr ""
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
 "TS: "
 msgstr ""
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr ""
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr ""
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr ""
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr ""
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
 "unknown option %x"
 msgstr ""
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr ""
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr ""
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr ""
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr ""
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr ""
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr ""
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr ""
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr ""
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr ""
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr ""
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr ""
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr ""
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr ""
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr ""
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr ""
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr ""
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr ""
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr ""
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr ""
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr ""
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr ""
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr ""
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr ""
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr ""
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr ""
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr ""
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr ""
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr ""
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr ""
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr ""
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr ""
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-26 18:38+0000\n"
 "Last-Translator: Jan Kuparinen <copper_fin@hotmail.com>\n"
 "Language-Team: Finnish <https://translate.fedoraproject.org/projects/iputils/"
@@ -145,9 +145,9 @@ msgstr "Liitäntä \"%s\" ei ole ARP-kysyttävä\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "VAROITUS: käytetään oletuskaikkilähetysosoitetta.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "virheellinen argumentti"
@@ -288,7 +288,7 @@ msgid "too long scope name"
 msgstr "liian pitkä laajuuden nimi"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "muistin varaus ei onnistunut"
 
@@ -342,7 +342,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "tuntematon iface: %s"
@@ -351,7 +351,7 @@ msgstr "tuntematon iface: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "laajuuden ero solmujen joukossa"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "Varoitus: lähdeosoite on saatettu valita muusta laitteesta kuin: %s"
@@ -397,7 +397,7 @@ msgstr "virtausnimiötä ei voi asettaa"
 msgid "can't send flowinfo"
 msgstr "ei voi lähettää virtaustietoja"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -407,7 +407,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", virtaus 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "%s %s:lta : "
@@ -552,7 +552,7 @@ msgstr "MLD-vähennys"
 msgid "unknown icmp type: %u"
 msgstr "tuntematon icmp-tyyppi: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "paikallinen virhe"
 
@@ -561,12 +561,12 @@ msgstr "paikallinen virhe"
 msgid "local error: message too long, mtu: %u"
 msgstr "paikallinen virhe: viesti liian pitkä, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "%s:lta icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -621,16 +621,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "paketti liian lyhyt: %d tavua"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "%s:lta: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "VAROITUS: pistorasiasuodattimen asennus epäonnistui"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "tuntematon protokollaperhe: %d"
@@ -673,78 +673,73 @@ msgstr "virheellinen TOS-arvo: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "TOS-bittien desimaaliarvon on oltava välillä 0–255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "vain yksi vaihtoehto '-4' tai '-6' voidaan määrittää"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "vain toista '-T':sta tai '-R':sta voidaan käyttää"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "virheellinen aikaleimatyyppi: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "huono ajoitusväli"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "huono ajoitusväli: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "'%s':ta ei voi kopioida"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "virheellinen lähdeosoite: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "ei voi asettaa esikuormitusta arvoon, joka on suurempi kuin kolme: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "virheellinen -M argumentti: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "huono viipymäaika"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "huono viipymäaika: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "Varoitus: käänteinen DNS-resoluutio (PTR-haku) poistettu käytöstä; vahvista "
 "'-H':lla"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "VAROITUS: ident 0 => pakotetaan raakapistoke"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "IPv4-Mapped-in-IPv6-osoite, käyttäen IPv4:ää %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "virheellinen -s-arvo: '%d': alueen ulkopuolella: 0 <= arvo <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -753,11 +748,11 @@ msgstr ""
 "Varoitus: IPv6-linkki-paikallinen osoite ICMP-datagrammiliitännässä saattaa "
 "vaatia ifnamen tai scope-id:n => use: address%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "varoitus: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -765,20 +760,20 @@ msgstr ""
 "Haluatko toteuta ping laaja-lähetyksellä? Sitten '-b'. Jos ei, tarkista "
 "paikalliset palomuurisäännöt"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "VAROITUS: laaja-lähetysosoitteen pingaaminen\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "laaja-lähetystä ei voi asettaa"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs epäonnistui"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -787,44 +782,44 @@ msgstr ""
 "minimiväli käyttäjän kaikkilähetyspingille on oltava >= %d ms, käytä -i %s "
 "(tai suurempi)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "laaja-lähetyksen ping ei pirstoudu"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "VAROITUS: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "VAROITUS: Linux-ytimesi on erittäin vanha. Ei ongelmia."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "VAROITUS: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "VAROITUS: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "ei voi poistaa monilähetyksen takaisin-silmukkaa käytöstä"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "ei voi asettaa monilähetyksen elon aikaa (TTL)"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "yksi-lähetyksen elon aikaa (TTL) ei voi asettaa"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) tavua dataa.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -833,7 +828,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -842,12 +837,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(sama reitti)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -856,7 +851,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -865,27 +860,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absoluuttinen ei-standardi"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld ei-standardi"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absoluuttinen"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Tallentamattomat hyppyt: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -894,232 +889,232 @@ msgstr ""
 "\n"
 "tuntematon vaihtoehto %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Kaiun vastaus\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Tavoittamaton kohdeverkko\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Tavoittamaton kohdeisäntä\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Tavoittamaton kohdeprotokolla\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Tavoittamaton kohdeportti\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Frag:ta tarvitaan ja DF asetettu (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Lähteen reitti epäonnistui\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Tuntematon kohdeverkko\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Tuntematon kohdeisäntä\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Lähdeisäntä eristettynä\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Kielletty kohdeverkko\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Kielletty kohdeisäntä\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Tavoittamaton kohdeverkko palvelutyypille\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Tavoittamaton kohdeisäntä palvelutyypille\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paketti suodatettu\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Ensisijaisuuden rikkominen\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Ensisijaisuuden raja\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Kohde tavoittamaton; huono koodi: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Lähde-Quench\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Ohjaa uudelleen verkko"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Ohjaa uudelleen isäntä"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Ohjaa uudelleen palvelun tyyppi ja verkko"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Ohjaa uudelleen palvelun tyyppi ja isäntä"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Ohjaa uudelleen; kelvoton koodi: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Uusi seuraava hyppy: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Kaikupyyntö\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Elinaika (TTL) ylitetty\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Frag:n uudelleenkokoamisaika ylitetty\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Aika ylitetty, kelvoton koodi: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Parametriongelma: osoitin = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Aikaleima\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Aikaleiman vastaus\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Tietopyyntö\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Tietovastaus\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Osoitepeitepyyntö\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Osoitepeitevastaus\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Kelvoton ICMP-tyyppi: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "paikallinen virhe: viesti liian pitkä; mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "paketti liian lyhyt (%d tavua) %s:sta"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "%s:sta: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(Kelvoton tarkistussumma)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(Kelvoton tarkistussumma)\n"
@@ -1562,6 +1557,10 @@ msgstr "takaisin %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlenin on oltava sisällä: %d < arvo <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "IPv4-Mapped-in-IPv6-osoite, käyttäen IPv4:ää %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Léane GRASSER <leane.grasser@proton.me>\n"
 "Language-Team: French <https://translate.fedoraproject.org/projects/iputils/"
@@ -147,9 +147,9 @@ msgstr "L’interface « %s » n’est pas ARPable\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "AVERTISSEMENT : utilisation de l’adresse de diffusion par défaut.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "paramètre invalide"
@@ -294,7 +294,7 @@ msgid "too long scope name"
 msgstr "le nom d'étendue est trop long"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "échec de l’allocation de mémoire"
 
@@ -348,7 +348,7 @@ msgstr ""
 "  subject-name=nom\n"
 "  subject-fqdn=nom\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "interface inconnue : %s"
@@ -357,7 +357,7 @@ msgstr "interface inconnue : %s"
 msgid "scope discrepancy among the nodes"
 msgstr "écart d'étendue entre les nœuds"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -405,7 +405,7 @@ msgstr "impossible de définir le label de flux"
 msgid "can't send flowinfo"
 msgstr "impossible d'envoyer l'information de flux"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -415,7 +415,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", flux 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "de %s %s : "
@@ -560,7 +560,7 @@ msgstr "Réduction MLD"
 msgid "unknown icmp type: %u"
 msgstr "type ICMP inconnu : %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "erreur locale"
 
@@ -569,12 +569,12 @@ msgstr "erreur locale"
 msgid "local error: message too long, mtu: %u"
 msgstr "erreur locale : le message est trop long : %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "De %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -629,16 +629,16 @@ msgstr "; seq=%u ;"
 msgid "packet too short: %d bytes"
 msgstr "paquet trop court : %d bytes"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "De %s : "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "AVERTISSEMENT : échec de l’installation du filtre de socket"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "famille de protocole inconnue : %d"
@@ -681,79 +681,74 @@ msgstr "mauvaise valeur de TOS : %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "la valeur décimale des bits TOS doit être entre 0 et 255 : %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "une seule option -4 ou -6 peut être renseignée"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "un seul parmi -T ou -R peut être utilisé"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "type de timestamp invalide : %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "mauvais intervalle de timing"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "mauvais intervalle de timing : %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "impossible de copier : %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "adresse source invalide : %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr ""
 "impossible de définir une valeur de préchargement plus grande que 3 : %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "paramètre -M invalide : %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "mauvais temps de persistance"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "mauvais temps de persistance : %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "AVERTISSEMENT : Résolution DNS inverse (recherche PTR) désactivée, forcer "
 "avec -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "AVERTISSEMENT : ident 0 => raw socket forcé"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "Adresse IPv4 au format IPv6, utilisation de l'adresse IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "valeur -s invalide : '%d' : hors limites : 0 <= valeur <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -762,11 +757,11 @@ msgstr ""
 "Avertissement : une adresse IPv6 link-local sur socket datagramme ICMP peut "
 "nécessité un ifname ou scope-id => utilisez : adresse%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "avertissement : QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -774,20 +769,20 @@ msgstr ""
 "Vous voulez faire un ping broadcast ? Alors utilisez -b, sinon veuillez "
 "vérifier les règles de votre pare-feu local."
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "AVERTISSEMENT : ping de l’adresse de diffusion\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "impossible de définir la multidiffusion"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "échec de gatifaddrs"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -796,44 +791,44 @@ msgstr ""
 "l'intervalle minimal de ping diffusé pour l'utilisateur doit être >=%d ms, "
 "utilisez -i %s (ou plus)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "le ping diffusé ne fragmente pas"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "AVERTISSEMENT : setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "AVERTISSEMENT : votre noyau est trèèès vieux. Aucun problème."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "AVERTISSEMENT : setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "AVERTISSEMENT : setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "impossible de désactiver la boucle de retour pour la multidiffusion"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "impossible de définir la durée de vie de la multidiffusion"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "impossible de définir la durée de vie de la monodiffusion"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) octets de données.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -842,7 +837,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -851,12 +846,12 @@ msgstr ""
 "\n"
 "%c SRR : "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(route identique)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -865,7 +860,7 @@ msgstr ""
 "\n"
 "RR : "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -874,27 +869,27 @@ msgstr ""
 "\n"
 "TS : "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absolut non standard"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld non standard"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absolut"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Sauts non comptabilités :%d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -903,232 +898,232 @@ msgstr ""
 "\n"
 "option inconnue %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Réponse Echo\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Réseau de destination injoignable\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Hôte de destination injoignable\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Protocole de destination injoignable\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Port de destination injoignable\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Fragmentation nécessaire et DF est défini (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Échec de la route source\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Réseau de destination inconnu\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Hôte de destination inconnu\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Hôte source isolé\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Réseau de destination interdit\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Hôte de destination interdit\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Réseau de destination injoignable pour Type de service\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Hôte de destination injoignable pour Type de service\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paquet filtré\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Violation de priorité\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Coupure de priorité\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Destination injoignable, mauvais code : %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Terminaison de source\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Rediriger le réseau"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Rediriger l'hôte"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Rediriger le type de service et réseau"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Rediriger le type de service et l'hôte"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Redirection, mauvais code : %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Nouveau sautsuivant : %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Requête Echo\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Durée de vie dépassée\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Temps de réassemblage des fragments dépassé\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Temps dépassé, mauvais code : %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Problème de paramètre : pointer = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Horodatage\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Réponse timestamp\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Demande d'information\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Réponse d'information\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Requête de masque d’adresse\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Réponse de masque d’adresse\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Mauvais type ICMP : %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "erreur locale : le message est trop long : mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "paquet trop court (%d bytes) de %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "De %s : icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(MAUVAISE SOMME DE CONTRÔLE)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(MAUVAISE SOMME DE CONTRÔLE)\n"
@@ -1583,6 +1578,10 @@ msgstr "retour %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen doit être entre : %d < valeur <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "Adresse IPv4 au format IPv6, utilisation de l'adresse IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.fedoraproject.org/projects/"
@@ -146,9 +146,9 @@ msgstr "Interface \"%s\" tidak ARPable\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "WARNING: menggunakan alamat broadcast bawaan.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "argumen tidak valid"
@@ -290,7 +290,7 @@ msgid "too long scope name"
 msgstr "nama scope terlalu panjang"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "alokasi memori gagal"
 
@@ -344,7 +344,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "iface tidak diketahui: %s"
@@ -353,7 +353,7 @@ msgstr "iface tidak diketahui: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "perbedaan scope antar node"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "Warning: alamat asal mungkin dipilih pada perangkat selain: %s"
@@ -399,7 +399,7 @@ msgstr "tidak bisa mengatur flowlabel"
 msgid "can't send flowinfo"
 msgstr "tidak bisa mengirim flowinfo"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -409,7 +409,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", flow 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "dari %s %s: "
@@ -554,7 +554,7 @@ msgstr "Reduksi MLD"
 msgid "unknown icmp type: %u"
 msgstr "tipe icmp tidak diketahui: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "kesalahan lokal"
 
@@ -563,12 +563,12 @@ msgstr "kesalahan lokal"
 msgid "local error: message too long, mtu: %u"
 msgstr "kesalahan lokal: pesan terlalu panjang, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "Dari %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -623,16 +623,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "paket terlalu singkat: %d byte"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "Dari %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "WARNING: gagal menginstall filter socket"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "protocol family tidak diketahui: %d"
@@ -675,78 +675,73 @@ msgstr "nilai TOS buruk: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "nilai desimal dari bit TOS harus dalam kisaran 0-255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "hanya satu opsi -4 atau -6 yang dapat ditentukan"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "hanya satu dari -T atau -R yang dapat digunakan"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "tipe timestamp tidak valid: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "interval waktu yang buruk"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "interval waktu yang buruk: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "tidak bisa menyalin: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "alamat asal tidak valid: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "tidak bisa mengatur preload ke nilai lebih besar dari 3: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "argumen -M tidak valid: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "waktu berlama-lama yang buruk"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "waktu berlama-lama yang buruk: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "PERINGATAN: resolusi DNS balik (pencarian PTR) dinonaktifkan, paksakan "
 "dengan -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "PERINGATAN: ident 0 => memaksa soket mentah"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "alamat IPv4-Dipetakan-dalam-IPv6, memakai IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "nilai -s tidak valid '%d': di luar rentang: 0 <= nilai <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -755,11 +750,11 @@ msgstr ""
 "Peringatan: Alamat link-local IPv6 pada soket datagram ICMP mungkin "
 "memerlukan ifname atau scope-id => gunakan: address%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "peringatan: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -767,20 +762,20 @@ msgstr ""
 "Apakah Anda ingin melakukan ping broadcast? Maka pilih opsi -b. Jika tidak, "
 "periksa aturan firewall lokal Anda"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "WARNING: ping alamat broadcast\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "tidak bisa mengatur broadcast"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs gagal"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -789,44 +784,44 @@ msgstr ""
 "internval minimum untuk ping broadcast bagi pengguna harus >= %d ms, gunakan "
 "-i %s (atau lebih tinggi)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "ping broadcast tidak terfragmentasi"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "PERINGATAN: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "WARNING: kernel Anda terlalu tua. Tidak ada masalah."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "PERINGATAN: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "PERINGATAN: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "tidak bisa menonaktifkan loopback multicast"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "tidak bisa mengatur time-to-live multicast"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "tidak bisa mengatur time-to-live unicast"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) byte data.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -835,7 +830,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -844,12 +839,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(route yang sama)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -858,7 +853,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -867,27 +862,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld mutlak tidak standar"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld tidak standar"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld mutlak"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Hop tidak tercatat: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -896,232 +891,232 @@ msgstr ""
 "\n"
 "opsi tidak diketahui %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Echo Balasan\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Jaringan Tujuan Tidak Terjangkau\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Host Tujuan Tidak Terjangkau\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Protokol Tujuan Tidak Terjangkau\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Port Tujuan Tidak Terjangkau\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Frag dibutuhkan dan DF diatur (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Rute Asal Gagal\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Jaringan Tujuan Tidak Diketahui\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Host Tujuan Tidak Diketahui\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Host Asal Terisolasi\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Jaringan Tujuan Terlarang\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Host Tujuan Terlarang\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Jaringan Tujuan Tidak Terjangkau untuk Type of Service\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Host Tujuan Tidak Terjangkau untuk Type of Service\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paket difilter\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Pelanggaran Prioritas\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Batas Prioritas\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Tujuan Tidak Terjangkau, Kode Buruk: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Source Quench\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Alihkan Network"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Alihkan Host"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Alihkan TOS dan Jaringan"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Alihkan TOS dan Host"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Redirect, Kode Buruk: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Nexthop baru: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Echo permintaan\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Time to live terlampaui\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Waktu reassembly fragmen terlampaui\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Waktu terlampaui, Kode Buruk: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Masalah parameter: pointer = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Cap waktu\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Timestamp Balasan\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Informasi Permintaan\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Informasi Balasan\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Mask Alamat Permintaan\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Mask Alamat Balasan\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Tipe ICMP buruk: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "kesalahan lokal: pesan terlalu panjang, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "packet terlalu singkat (%d byte) dari %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "Dari %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(BAD CHECKSUM)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(BAD CHECKSUM)\n"
@@ -1566,6 +1561,10 @@ msgstr "kembali %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "panjang paket harus dalam: %d < nilai <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "alamat IPv4-Dipetakan-dalam-IPv6, memakai IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -124,9 +124,9 @@ msgstr ""
 msgid "WARNING: using default broadcast address.\n"
 msgstr ""
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr ""
@@ -249,7 +249,7 @@ msgid "too long scope name"
 msgstr ""
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgid ""
 "  subject-fqdn=name\n"
 msgstr ""
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 msgid "scope discrepancy among the nodes"
 msgstr ""
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -338,7 +338,7 @@ msgstr ""
 msgid "can't send flowinfo"
 msgstr ""
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr ""
@@ -348,7 +348,7 @@ msgstr ""
 msgid ", flow 0x%05x, "
 msgstr ""
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr ""
@@ -493,7 +493,7 @@ msgstr ""
 msgid "unknown icmp type: %u"
 msgstr ""
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr ""
 
@@ -502,12 +502,12 @@ msgstr ""
 msgid "local error: message too long, mtu: %u"
 msgstr ""
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr ""
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr ""
@@ -562,16 +562,16 @@ msgstr ""
 msgid "packet too short: %d bytes"
 msgstr ""
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr ""
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr ""
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr ""
@@ -614,435 +614,430 @@ msgstr ""
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr ""
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr ""
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr ""
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr ""
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr ""
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr ""
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr ""
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr ""
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr ""
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr ""
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr ""
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr ""
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr ""
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
 "or scope-id => use: address%%<ifname|scope-id>"
 msgstr ""
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr ""
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
 msgstr ""
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr ""
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr ""
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr ""
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr ""
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr ""
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr ""
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr ""
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr ""
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr ""
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr ""
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr ""
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
 "NOP"
 msgstr ""
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
 "%cSRR: "
 msgstr ""
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr ""
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
 "RR: "
 msgstr ""
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
 "TS: "
 msgstr ""
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr ""
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr ""
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr ""
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr ""
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
 "unknown option %x"
 msgstr ""
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr ""
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr ""
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr ""
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr ""
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr ""
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr ""
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr ""
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr ""
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr ""
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr ""
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr ""
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr ""
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr ""
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr ""
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr ""
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr ""
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr ""
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr ""
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr ""
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr ""
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr ""
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr ""
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr ""
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr ""
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr ""
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr ""
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr ""
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr ""
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr ""
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr ""
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr ""
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils 20161105\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-09-03 06:23+0000\n"
 "Last-Translator: Weblate Translation Memory <noreply-mt-weblate-translation-"
 "memory@weblate.org>\n"
@@ -150,9 +150,9 @@ msgstr "インタフェース \"%s\" ではARPを利用できません\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "警告: 既定のブロードキャストアドレスを使用しています。\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "無効な引数です"
@@ -298,7 +298,7 @@ msgstr "スコープ名が長すぎます"
 
 #
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "メモリ確保に失敗しました"
 
@@ -353,7 +353,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "不明なインタフェースです: %s"
@@ -363,7 +363,7 @@ msgstr "不明なインタフェースです: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "ノード間のスコープが一致していません"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "警告: ソースアドレスは %s 以外のデバイスから選択される可能性があります"
@@ -410,7 +410,7 @@ msgstr "フローラベルを設定できません"
 msgid "can't send flowinfo"
 msgstr "フロー情報を送信できません"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -420,7 +420,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", フロー 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "送信元 %s %s: "
@@ -566,7 +566,7 @@ msgid "unknown icmp type: %u"
 msgstr "未知のicmpの種別です: %u"
 
 #
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "内部エラー"
 
@@ -575,12 +575,12 @@ msgstr "内部エラー"
 msgid "local error: message too long, mtu: %u"
 msgstr "内部エラー: メッセージが長すぎます: mtu=%u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "送信元 %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -635,17 +635,17 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "パケットが短すぎます: %d バイト"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "送信元 %s: "
 
 #
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "警告: ソケットフィルタのインストールに失敗しました"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "プロトコルファミリーが不明です: %d"
@@ -689,79 +689,74 @@ msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "TOSビット %d は10進値で0-255でなければいけません"
 
 #
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "-4 か -6 のどちらか一方のみを使うことができます"
 
 #
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "-T か -R のどちらか一方のみを使うことができます"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "無効なタイムスタンプ種別です: %s"
 
 #
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "不正な間隔です"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "は不正な間隔です: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "コピーできません: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "無効なソースアドレスです: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "preloadの値は 3 以上に設定できません: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "不正な -M オプション値です: %s"
 
 #
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "応答待ち時間が正しくありません"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "応答待ち時間が正しくありません: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr "警告: DNS逆引き (PTR取得) は無効化されており、-Hで有効化可能です"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "警告: ident 0 => 強制的にrawソケットを使用します"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -772,12 +767,12 @@ msgstr ""
 "用いてください"
 
 #
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "警告: QOSソケットオプションの設定エラーが発生しました"
 
 #
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -785,22 +780,22 @@ msgstr ""
 "ブロードキャストpingを行う場合は -b オプション、違う場合はファイアウォールを"
 "確認してください"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "警告: ブロードキャストアドレスにpingしています\n"
 
 #
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "ブロードキャストを設定できません"
 
 #
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrsに失敗しました"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -810,48 +805,48 @@ msgstr ""
 "使用してください"
 
 #
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "ブロードキャストpingパケットは断片化しません"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "警告: setsockopt(ICMP_FILTER)"
 
 #
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "警告: kernelが非常に古いです。問題ありません。"
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "警告: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "警告: setsockopt(IP_RETOPTS)"
 
 #
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "マルチキャスト・ループバックを無効にできません"
 
 #
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "マルチキャストTTLを設定できません"
 
 #
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "ユニキャストTTLを設定できません"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) バイトのデータ\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -860,7 +855,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -869,12 +864,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(同一経路)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -883,7 +878,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -892,27 +887,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld 非標準の絶対値"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld 非標準"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld 絶対値"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "記録されていないホップ数: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -921,232 +916,232 @@ msgstr ""
 "\n"
 "%x は不明なオプションです"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "エコー応答\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "目的のネットワークへ届きません。\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "目的のホストへ届きません。\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "目的のプロトコルへ届きません。\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "目的のポートへ届きません。\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "断片化が必要ですがDFフラグがセットされています (mtu = %u)。\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "ソースルーティングに失敗しました。\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "目的のネットワークが不明です。\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "目的のホストが不明です。\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "送信元ホストが孤立しています。\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "目的のネットワークは禁止されています。\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "目的のホストは禁止されています。\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "このtosでは目的のネットワークへ届きません。\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "このtosでは目的のホストへ届きません。\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "パケットがフィルタリングされました。\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "優先度違反\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "優先度に基づく遮断\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "目的サイトへ届きません, 不正なコード: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "発信抑制\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "ネットワークのリダイレクト"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "ホストのリダイレクト"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "TOSのためのネットワークリダイレクト"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "TOSのためのホストリダイレクト"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "リダイレクト, 不正なコード: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(新しい次ホップ: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "エコー要求\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "TTLを超過しました。\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "断片化パケットの再構築時間を超過しました。\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "時間超過です。不正なコード: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "パラメータの問題: ポインタ = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "タイムスタンプ\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "タイムスタンプ応答\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "情報要求\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "情報応答\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "アドレスマスク要求\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "アドレスマスク応答\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "不正なICMP種別です: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "内部エラー: メッセージが長すぎます: mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "パケットが短すぎます (%d バイト)。送信元 %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "送信元 %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(チェックサム異常)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(チェックサム異常)\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <https://translate.fedoraproject.org/projects/"
@@ -147,9 +147,9 @@ msgstr "ინტერფეისს \"%s\" ARP ცხრილი არ გ�
 msgid "WARNING: using default broadcast address.\n"
 msgstr "გაფრთხილება: გამოიყენება გადაცემის ნაგულისხმევი მისამართი.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "არასწორი არგუმენტი"
@@ -292,7 +292,7 @@ msgid "too long scope name"
 msgstr "რეგიონის მეტისმეტად გრძელი სახელი"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "მეხსიერების გამოყოფის შეცდომა"
 
@@ -346,7 +346,7 @@ msgstr ""
 "  subject-name=სახელი\n"
 "  subject-fqdn=სახელი\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "უცნობი ინტერფეისი: %s"
@@ -355,7 +355,7 @@ msgstr "უცნობი ინტერფეისი: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "ფარგლების შეუსაბამობა კვანძებს შორის"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr "დინების ჭდის დადების შეცდო
 msgid "can't send flowinfo"
 msgstr "დინების ინფორმაციის გაგზავნის შეცდომა"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -412,7 +412,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", დინება 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "%s%s-დან: "
@@ -557,7 +557,7 @@ msgstr "MLD შემცირება"
 msgid "unknown icmp type: %u"
 msgstr "icmp-ის უცნობი ტიპი: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "ლოკალური შეცდომა"
 
@@ -566,12 +566,12 @@ msgstr "ლოკალური შეცდომა"
 msgid "local error: message too long, mtu: %u"
 msgstr "ლოკალური შეცდომა: შეტყობინება ძალიან გრძელია. mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "%s -დან icm_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq =%u"
@@ -626,16 +626,16 @@ msgstr "; seq =%u;"
 msgid "packet too short: %d bytes"
 msgstr "პაკეტი ძალიან მოკლეა: %d ბაიტი"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "%s-დან: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "გაფრთხილება: სოკეტის ფილტრის დაყენების შეცდომა"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "პროტოკოლის არასწორი ოჯახი: %d"
@@ -679,79 +679,74 @@ msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr ""
 "TOS-ის ბიტების რიცხვის მთელი მნიშვნელობა 0-255 დიაპაზონში უნდა იყოს: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "პარამეტრებიდან -4 და -6 შეიძლება მიუთითოთ მხოლოდ ერთერთი"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "პარამეტრებიდან -T და -R შეიძლება მიუთითოთ მხოლოდ ერთერთი"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "დროის სანიშნის არასწორი ტიპი: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "ინტერვალის არასწორი დრო"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "დროის არასწორი ინტერვალი: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "%s-ის კოპირება შეუძლებელია"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "არასწორი საწყისი მისამართი: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "წინასწარი ჩატვირთვის მნიშვნელობა არ შეიძლება 3-ზე დიდი იყოს: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "-M-ის არასწორი არგუმენტი: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "გაწელვის ცუდი დრო"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "დაყოვნების არასწორი დრო: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "გაფრთხილება: შებრუნებული DNS ამოხსნა (PTR-ის ძებნა) გამორთულია. ჩართეთ ის "
 "ძალით პარამეტრით -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "გაფრთხილება: ident 0 => raw ტიპის სოკეტის ნაძალადევი არჩევა"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "IPv4 ასახული IPv6 მისამართზე. გამოიყენება IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 "არასწორი მნიშვნელობა -s-სთვის: '%d': შუალედს გარეთაა: 0 <= მნიშვნელობა <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -760,11 +755,11 @@ msgstr ""
 "გაფრთხილება: IPv6 link-local misamarTs ICMP დატაგრამის სოკეტზე შეიძლება "
 "ifname an scope-id => use: address%%<ifname|scope-id> დასჭირდეს"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "გაფრთხილება: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -772,20 +767,20 @@ msgstr ""
 "ტრანსლირების მისამართის დასაპინგად გამოიყენეთ პარამეტრი -b. თუ არა, "
 "შეამოწმეთ ლოკალური ბრანდმაუერის წესები"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "გაფრთხილება: პინგავთ ტრანსლირების მისამართს\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "გადაცემის დაყენების შეცდომა"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs-ის შეცდომა"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -794,46 +789,46 @@ msgstr ""
 "მინიმალური ინტერვალი მაუწყებლობის პინგისთვის მომხმარებლისთვის უნდა იყოს >=%d "
 "მწმ. გამოიყენეთ -i %s (ან უფრო მაღალი)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "ტრანსლირების პინგი არ იხლიჩება"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "გაფრთხილება: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr ""
 "გაფრთხილება: ოპერაციული სისტემის თქვენი ბირთვი ამაზრზენად ძველია. პრობლემა "
 "არაა."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "გაფრთხილება: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "გაფრთხილება: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "გადაცემის მარყუჟის გათიშვის შეცდომა"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "გადაცემის TTL-ის დაყენების შეცდომა"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "უნიკასტის TTL-ის დაყენების შეცდომა"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d (%d) ბაიტი მონაცემები.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -842,7 +837,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -851,12 +846,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(იგივე გზა)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -865,7 +860,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -874,27 +869,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld აბსოლუტური არასტანდარტული"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\tარასტანდარტული %ld"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\tზუსტი %ld"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "ჩაუწერელი ჰოპები: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -903,233 +898,233 @@ msgstr ""
 "\n"
 "უცნობი პარამეტრი %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr ""
 "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst მონაცემები\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x%04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x%04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "პასუხი ექოზე\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "სამიზნე ქსელი მიუწვდომელია\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "სამიზნე ჰოსტი ხელმიუწვდომელია\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "სამიზნე პროტოკოლი ხელმიუწვდომელია\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "სამიზნე პორტი ხელმიუწვდომელია\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "საჭიროა DF ბიტისა და დახლეჩვის ჩართვა (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "საწყისი რაუტის შეცდომა\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "სამიზნე ქსელი უცნობია\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "სამიზნე ჰოსტი უცნობია\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "საწყისი ჰოსტი იზოლირებულია\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "სამიზნე ქსელი აკრძალულია\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "სამიზნე ჰოსტი აკრძალულია\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "TOS-ის სამიზნე ქსელი მიუწვდომელია\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "ToS-ისთვის სამიზნე ჰოსტი მიუწვდომელია\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "პაკეტი გაიფილტრა\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "თანამიმდევრობის დარღვევა\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "თანამიმდევრობის ამოჭრა\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "სამიზნე მიუწვდომელია. კოდი: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "წყაროს შეწყვეტა\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "ქსელის გადამისამართება"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "ჰოსტის გადამისამართება"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "გადამისამართების ToS და ქსელი"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "გადამისამართების ToS და ჰოსტი"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "გადამისამართება ცუდი კოდით: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(ახალი შემდგომი ჰოპია: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "ექოს მოთხოვნა\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "TTL გადაჭარბებულია\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "დანახლეჩის აწყობის დრო გავიდა\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "დრო გასულია. ცუდი კოდი: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "პარამეტრის პრობლემა: მაჩვენებელი = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "დროის სანიშნი\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "დროის სანიშნის პასუხი\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "ინფორმაციის მოთხოვნა\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "საპასუხო ინფორმაცია\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "მისამართის ნიღბის მოთხოვნა\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "მისამართის ნიღბის პასუხი\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "ICMP-ის არასწორი ტიპი: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "ლოკალური შეცდომა: შეტყობინება ძალიან გრძელია. mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "პაკეტი ძალიან მოკლეა (%d ბაიტი). გამომგზავნი:%s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "%s-დან: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(არასწორი საკონტროლო ჯამი)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(არასწორი საკონტროლო ჯამი)\n"
@@ -1581,6 +1576,10 @@ msgstr "უკან %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen-ის დიაპაზონი: %d < მნიშვნელობა <=%d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "IPv4 ასახული IPv6 მისამართზე. გამოიყენება IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/kab.po
+++ b/po/kab.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: ButterflyOfFire <butterflyoffire@users.noreply.translate."
 "fedoraproject.org>\n"
@@ -126,9 +126,9 @@ msgstr ""
 msgid "WARNING: using default broadcast address.\n"
 msgstr ""
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr ""
@@ -253,7 +253,7 @@ msgid "too long scope name"
 msgstr ""
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgid ""
 "  subject-fqdn=name\n"
 msgstr ""
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr ""
@@ -298,7 +298,7 @@ msgstr ""
 msgid "scope discrepancy among the nodes"
 msgstr ""
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "can't send flowinfo"
 msgstr ""
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr ""
@@ -352,7 +352,7 @@ msgstr ""
 msgid ", flow 0x%05x, "
 msgstr ""
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr ""
@@ -497,7 +497,7 @@ msgstr ""
 msgid "unknown icmp type: %u"
 msgstr ""
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "tuccḍa tadigant"
 
@@ -506,12 +506,12 @@ msgstr "tuccḍa tadigant"
 msgid "local error: message too long, mtu: %u"
 msgstr ""
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr ""
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr ""
@@ -566,16 +566,16 @@ msgstr ""
 msgid "packet too short: %d bytes"
 msgstr ""
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "Seg %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr ""
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr ""
@@ -618,435 +618,430 @@ msgstr ""
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr ""
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr ""
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr ""
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr ""
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr ""
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr ""
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr ""
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr ""
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr ""
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr ""
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr ""
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr ""
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr ""
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
 "or scope-id => use: address%%<ifname|scope-id>"
 msgstr ""
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr ""
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
 msgstr ""
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr ""
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr ""
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr ""
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr ""
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr ""
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr ""
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr ""
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr ""
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr ""
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr ""
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr ""
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) itamḍanen n yifeska.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
 "NOP"
 msgstr ""
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
 "%cSRR: "
 msgstr ""
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(abrid-is yiwen)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
 "RR: "
 msgstr ""
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
 "TS: "
 msgstr ""
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr ""
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr ""
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr ""
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr ""
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
 "unknown option %x"
 msgstr ""
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr ""
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr ""
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr ""
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr ""
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr ""
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr ""
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr ""
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr ""
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr ""
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr ""
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr ""
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr ""
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr ""
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr ""
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr ""
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr ""
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr ""
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr ""
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr ""
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr ""
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr ""
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr ""
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr ""
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr ""
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr ""
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr ""
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr ""
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr ""
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr ""
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr ""
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr ""
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr ""
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr ""
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr ""
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr ""
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr ""
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-22 13:38+0000\n"
 "Last-Translator: 김인수 <simmon@nplob.com>\n"
 "Language-Team: Korean <https://translate.fedoraproject.org/projects/iputils/"
@@ -146,9 +146,9 @@ msgstr "\"%s\" 인터페이스는 주소 변환을 할 수 없습니다\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "경고: 기본 광역 전송 주소를 사용합니다.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "부적절한 인자"
@@ -290,7 +290,7 @@ msgid "too long scope name"
 msgstr "너무 긴 범위 이름"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "메모리 할당에 실패했습니다"
 
@@ -344,7 +344,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "알 수 없는 iface: %s"
@@ -353,7 +353,7 @@ msgstr "알 수 없는 iface: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "노드 사이의 범위 불일치"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "경고: 원천 주소는 다른 이외의 장치에서 선택될 수 있습니다: %s"
@@ -399,7 +399,7 @@ msgstr "흐름부호(flowlabel)를 설정 할 수 없습니다"
 msgid "can't send flowinfo"
 msgstr "흐름 정보를 보낼 수 없습니다"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -409,7 +409,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", flow 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "%s %s에서: "
@@ -554,7 +554,7 @@ msgstr "MLD 축소"
 msgid "unknown icmp type: %u"
 msgstr "알 수 없는 icmp 형식: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "로컬 오류"
 
@@ -563,12 +563,12 @@ msgstr "로컬 오류"
 msgid "local error: message too long, mtu: %u"
 msgstr "로컬 오류: 메시지가 너무 길음, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "%s에서 icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -623,16 +623,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "패킷이 너무 짧음: %d 바이트"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "%s에서: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "경고: 소켓 필터를 설치하는데 실패함"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "알 수 없는 프로토콜 계열: %d"
@@ -675,77 +675,72 @@ msgstr "잘못된 TOS 값: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "TOS 비트의 십진수 값은 범위가 0-255 이어야 합니다: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "-4 또는 -6 선택은 하나만 지정 할 수 있습니다"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "-T 또는 -R 중의 하나만 사용 될 수 있습니다"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "부적절한 타임스탬프 형식: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "나쁜 시간 간격"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "나쁜 시간 간격: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "복사 할 수 없음: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "부적절한 원시 주소: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "미리 적재된 값이 3보다 크게 설정 할 수 없습니다: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "부적절한 -M 인자: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "나쁜 체류시간"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "나쁜 체류시간: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "경고: 역방향 DNS 확인 (PTR 조회)은 비활성화 되었고, -H와 함께 강제합니다"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "경고: ident 0 => 원시 소켓으로 강제합니다"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "IPv4 %s 사용하여 IPv6 주소에서-대응된-IPv4"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "잘못된 -s 값: '%d': 범위 초과: 0 <= 값 <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -754,11 +749,11 @@ msgstr ""
 "경고: ICMP 데이타그램에서 IPv6 연결-로컬 주소는 ifname 또는 scope-id가 요구 "
 "될 수 있습니다 => use: address%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "경고: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -766,20 +761,20 @@ msgstr ""
 "ping 광역전송을 할까요? 그런 다음 -b. 만약 그렇지 않으면, 로컬 방화벽 규칙을 "
 "점검하세요"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "경고: 핑하는 광역전송 주소\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "광역전송 중에 설정 할 수 없습니다"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs 실패함"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -788,44 +783,44 @@ msgstr ""
 "사용자의 브로드캐스팅 핑을 위한 최소 허용 간격은 %d ms이며, -i %s (또는 그 이"
 "상)를 사용합니다"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "광역전송 핑이 조각화되지 않음"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "경고: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "경고: 당신의 커널은 아주~ 오래되었습니다. 문제 없습니다."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "경고: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "경고: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "광역전송 루프백을 비활성화 할 수 없습니다"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "광역전송 유효기간(ttl)을 설정 할 수 없습니다"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "단일전송 유효기간(ttl)을 설정 할 수 없습니다"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "자료의 %d(%d) 바이트.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -834,7 +829,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -843,12 +838,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(동일 경로)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -857,7 +852,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -866,27 +861,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld 절대 비-표준"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld 비-표준"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld 절대의"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "기록되지 않는 건너뛰기: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -895,232 +890,232 @@ msgstr ""
 "\n"
 "알지 못하는 옵션 %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst 자료\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "반향 응답\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "대상 넷에 도달 할 수 없음\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "대상 호스트에 도달 할 수 없음\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "대상 통신규악에 도달 할 수 없음\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "대상 포트에 도달 할 수 없음\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "조각화가 필요하고 DF 설정(mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "원천 경로에 실패함\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "대상 넷을 알지 못함\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "대상 호스트를 알지 못함\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "원천 호스트가 격리됨\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "대상 넷이 금지됨\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "대상 호스트가 금지됨\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "서비스 형식으로 대상 네트워크에 도달할 수 없습니다\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "서비스 유형을 위해 대상 호스트에 도달 할 수 없습니다\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "패킷이 필터링됨\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "우선 순위 위반\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "우선순위 효력 차단\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "대상에 도달 할 수 없으며, 잘못된 코드: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "발신 제한\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "네트워크 넘겨주기"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "호스트 넘겨주기"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "서비스 및 네트워크의 경로 재지정 형식"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "서비스 및 호스트의 경로 재지정 형식"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "넘겨주기, 잘못된 코드: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(신규 다음 건너뛰기: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "반향 요청\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "유효기간(ttl)이 초과됨\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "조각 재결합 시간이 초과됨\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "시간이 초과되었으며, 잘못된 코드: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "매개변수 문제: pointer = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "시간표기\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "시간표기 응답\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "정보 요청\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "정보 응답\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "주소 매스크 요청\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "주소 매스크 응답\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "잘못된 ICMP 형식: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "로컬 오류: 메시지가 너무 김, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "패킷이 너무 짧음(%d 바이트) (%s에서)"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "%s에서: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(잘못된 검사합)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(잘못된 검사합)\n"
@@ -1563,6 +1558,10 @@ msgstr "%d 뒤로 "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen은 다음 값 안에 있어야 합니다: %d < 값 <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "IPv4 %s 사용하여 IPv6 주소에서-대응된-IPv4"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-09-02 17:24+0000\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.fedoraproject.org/"
@@ -146,9 +146,9 @@ msgstr "Interface \"%s\" não está ARPável\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "AVISO: usando endereço padrão de broadcast.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "argumento inválido"
@@ -291,7 +291,7 @@ msgid "too long scope name"
 msgstr "nome de escopo longo demais"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "alocação de memória falhou"
 
@@ -345,7 +345,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "interface desconhecida: %s"
@@ -354,7 +354,7 @@ msgstr "interface desconhecida: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "discrepância de escopo entre os nós"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -401,7 +401,7 @@ msgstr "não foi possível definir flowlabel (rótulo de fluxo)"
 msgid "can't send flowinfo"
 msgstr "não foi possível enviar flowinfo (informações de fluxo)"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -411,7 +411,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", fluxo 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "de %s %s: "
@@ -556,7 +556,7 @@ msgstr "Redução de MLD"
 msgid "unknown icmp type: %u"
 msgstr "tipo de icmp desconhecido: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "erro local"
 
@@ -565,12 +565,12 @@ msgstr "erro local"
 msgid "local error: message too long, mtu: %u"
 msgstr "erro local: mensagem longa demais, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "De %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -625,16 +625,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "pacote curto demais: %d bytes"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "De %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "AVISO: falha ao instalar filtro de socket"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "família de protocolo desconhecida: %d"
@@ -677,76 +677,71 @@ msgstr "valor de TOS inválido: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "o valor em decimal de bits TOS deve estar no intervalo 0-255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "apenas uma opção entre -4 ou -6 pode ser especificada"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "apenas um entre -T ou -R pode ser usado"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "tipo de marca de tempo inválido: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "intervalo de tempo inválido"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "intervalo de tempo inválido: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "não foi possível copiar: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "endereço de origem inválido: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "não foi possível pré-carregar para um valor maior que 3: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "argumento -M inválido: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "tempo de espera inválido"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "tempo de espera inválido: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr "AVISO: resolução DNS reversa (pesquisa PTR) desabilitada, force com -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "AVISO: ident 0 => forçando socket não tratado"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -755,11 +750,11 @@ msgstr ""
 "Aviso: endereço de enlace local IPv6 no socket de datagrama ICMP pode "
 "precisar de ifname ou scope-id => use: endereço%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "aviso: sockopts de QOS"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -767,20 +762,20 @@ msgstr ""
 "Deseja enviar ping em broadcast? Então, -b. Caso contrário, verifique suas "
 "regras de firewall local"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "AVISO: pingando endereço de broadcast\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "não foi possível definir uso de broadcast"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs falhou"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -789,44 +784,44 @@ msgstr ""
 "intervalo mínimo para ping broadcast para usuário deve ser >= %d ms, use -i "
 "%s (ou mais)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "o ping de broadcast não fragmenta"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "AVISO: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "AVISO: seu kernel é beeem antigo. Sem problemas."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "AVISO: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "AVISO: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "não foi possível desabilitar loopback em multicast"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "não foi possível definir tempo de vida multicast"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "não foi possível definir tempo de vida unicast"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) bytes de dados.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -835,7 +830,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -844,12 +839,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(mesma rota)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -858,7 +853,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -867,27 +862,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absoluta não padrão"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld não padrão"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absoluta"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Saltos não registrados: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -896,232 +891,232 @@ msgstr ""
 "\n"
 "opção desconhecida %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Resposta de eco\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Rede de destino inalcançável\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Host de destino inalcançável\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Protocolo de destino inalcançável\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Porta de destino inalcançável\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Frag necessária e DF definida (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Rota da origem falhou\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Rede de destino desconhecida\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Host de destino desconhecido\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Host de origem isolado\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Rede de destino proibida\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Host de destino proibido\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Rede de destino inalcançável para o tipo de serviço\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Host de destino inalcançável para o tipo de serviço\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Pacote filtrado\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Violação de precedência\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Corte de precedência\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Destino inalcançável, código inválido: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Source Quench\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Redirecionamento de rede"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Redirecionamento de host"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Redirecionamento de tipo de serviço e rede"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Redirecionamento de tipo de serviço e host"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Redirecionamento, código inválido: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Novo próximo salto: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Requisição de eco\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Tempo de vida excedido\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Tempo de remontagem de frag excedido\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Tempo excedido, código inválido: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Problema de parâmetro: ponteiro = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Marca de tempo\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Resposta de marca de tempo\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Requisição de informação\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Resposta de informação\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Requisição da máscara de endereço\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Resposta da máscara de endereço\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Tipo inválido de ICMP: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "erro local: mensagem longa demais, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "pacote curto demais (%d bytes) de %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "De %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(SOMA DE VERIFICAÇÃO INVÁLIDA)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(SOMA DE VERIFICAÇÃO INVÁLIDA)\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <https://translate.fedoraproject.org/projects/"
@@ -151,9 +151,9 @@ msgstr ""
 msgid "WARNING: using default broadcast address.\n"
 msgstr "AVERTISMENT: se utilizează adresa de difuzare implicită.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "argument nevalid"
@@ -300,7 +300,7 @@ msgid "too long scope name"
 msgstr "nume de domeniu de aplicare prea lung"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "alocarea memoriei a eșuat"
 
@@ -354,7 +354,7 @@ msgstr ""
 "  subject-name=nume\n"
 "  subject-fqdn=nume\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "interfață necunoscută: %s"
@@ -363,7 +363,7 @@ msgstr "interfață necunoscută: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "discrepanță de domeniu de aplicare între noduri"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -410,7 +410,7 @@ msgstr "nu se poate defini eticheta fluxului"
 msgid "can't send flowinfo"
 msgstr "nu se pot trimite informațiile privind fluxul"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -420,7 +420,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", flux 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "de la %s %s: "
@@ -565,7 +565,7 @@ msgstr "Reducere MLD"
 msgid "unknown icmp type: %u"
 msgstr "tip de icmp necunoscut: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "eroare locală"
 
@@ -574,12 +574,12 @@ msgstr "eroare locală"
 msgid "local error: message too long, mtu: %u"
 msgstr "eroare locală: mesaj prea lung, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "De la %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -634,16 +634,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "pachet prea scurt: %d octeți"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "De la %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "AVERTISMENT: Instalarea filtrului de soclu a eșuat"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "familie de protocoale necunoscută: %d"
@@ -686,78 +686,73 @@ msgstr "valoare TOS greșită: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "valoarea zecimală a biților TOS trebuie să fie în intervalul 0-255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "poate fi specificată o singură opțiune „-4” sau „-6”"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "poate fi utilizată doar una dintre opțiunile „-T” sau „-R”"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "tip de marcă de timp nevalidă: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "interval de cronometrare greșit"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "interval de cronometrare greșit: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "nu se poate copia: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "adresă sursă nevalidă: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "nu se poate stabili preîncărcarea la o valoare mai mare de 3: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "argument al opțiunii „-M” nevalid: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "timp de persistență greșit"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "timp de persistență greșit: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "AVERTISMENT: rezoluția DNS inversă (căutarea PTR) este dezactivată, poate fi "
 "activată forțat cu „-H”"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "AVERTISMENT: ident 0 => se forțează soclul brut (neprocesat)"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "adresă IPv4 transpusă în adresă IPv6, utilizând IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "valoare „-s” nevalidă: „%d”: în afara intervalului: 0 <= valoare <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -767,11 +762,11 @@ msgstr ""
 "necesita un nume de interfață sau un id de domeniul de aplicare => utilizați "
 "următoarele: adresa%%<nume-interfață|id-de-domeniul-de-aplicare>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "avertizare: sockopts QOS"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -779,20 +774,20 @@ msgstr ""
 "Doriți să faceți ping la difuzare? Utilizați atunci opțiunea „-b”. Dacă nu, "
 "verificați regulile paravanului de protecție local"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "ATENȚIE: verificarea prin ping a adresei de difuzare\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "nu se poate configura difuzarea"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs a eșuat"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -801,44 +796,44 @@ msgstr ""
 "intervalul minim pentru efectuarea unui ping de difuzare pentru utilizator "
 "trebuie să fie >= %d ms, utilizați „-i %s” (sau mai mare)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "ping-ul de difuzare nu este fragmentat"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "AVERTISMENT:: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "AVERTISMENT: nucleul dvs. este foarte vechi. Nu este nicio problemă."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "AVERTISMENT: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "AVERTISMENT: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "nu se poate dezactiva bucla de retur multi-difuzare"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "nu se poate defini durata de existență a multi-difuzării"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "nu se poate defini durata de existență a uni-difuzării (unicast)"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) octeți de date.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -847,7 +842,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -856,12 +851,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(aceeași rută)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -870,7 +865,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -879,27 +874,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld absolută nestandard"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld nestandard"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld absolută"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Salturi neînregistrate: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -908,232 +903,232 @@ msgstr ""
 "\n"
 "opțiune necunoscută %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Lung  ID Fan  off TTL Pro  verif    Sursa   Dest Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Răspuns Ecou\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Rețea de destinație inaccesibilă\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Gazdă de destinație inaccesibilă\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Protocol de destinație inaccesibil\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Port de destinație inaccesibil\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Este necesară fragmentarea și definirea DF (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Ruta sursă a eșuat\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Rețea de destinație necunoscută\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Gazdă de destinație necunoscută\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Gazdă sursă izolată\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Rețea de destinație interzisă\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Gazdă de destinație interzisă\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Rețea de destinație inaccesibilă pentru tipul de serviciu\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Gazdă de destinație inaccesibilă pentru tipul de serviciu\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Pachet filtrat\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Încălcarea priorității\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Limită de prioritate\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Destinație inaccesibilă, cod greșit: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Oprirea sursei\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Redirecționarea rețelei"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Redirecționarea gazdei"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Redirecționarea tipului de serviciu și a rețelei"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Redirecționarea tipului de serviciu și a gazdei"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Redirecționare, cod greșit: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Noul salt următor: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Cerere de Ecou\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Durata de existență a fost depășită\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Timpul de reasamblare a fragmentelor a fost depășit\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Limita de timp a fost depășită, cod greșit: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Problemă de parametru: indicator = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Marca de timp\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Răspuns de la marca de timp\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Cerere de informații\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Răspuns la informații\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Cerere de mască de adresă\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Răspuns de mască de adresă\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Tip ICMP greșit: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "eroare locală: mesaj prea lung, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "pachet prea scurt (%d octeți) de la %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "De la %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(SUMĂ DE CONTROL GREȘITĂ)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(SUMĂ DE CONTROL GREȘITĂ)\n"
@@ -1596,3 +1591,7 @@ msgstr "returnare %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen trebuie să fie cuprins între: %d < valoare <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "adresă IPv4 transpusă în adresă IPv6, utilizând IPv4 %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
 "Language-Team: Turkish <https://translate.fedoraproject.org/projects/iputils/"
@@ -146,9 +146,9 @@ msgstr "\"%s\" arayüzü ARP için uygun değil\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "UYARI: öntanımlı genel yayın adresi kullanılıyor.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "geçersiz argüman"
@@ -291,7 +291,7 @@ msgid "too long scope name"
 msgstr "çok uzun kapsam adı"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "bellek ayırma başarısız"
 
@@ -345,7 +345,7 @@ msgstr ""
 "  subject-name=ad\n"
 "  subject-fqdn=ad\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "bilinmeyen arayüz: %s"
@@ -354,7 +354,7 @@ msgstr "bilinmeyen arayüz: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "düğümler arasındaki kapsam uyuşmazlığı"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "Uyarı: kaynak adresi \"%s\" dışında bir aygıtta seçilebilir"
@@ -400,7 +400,7 @@ msgstr "akış etiketi ayarlanamıyor"
 msgid "can't send flowinfo"
 msgstr "akış bilgisi gönderilemiyor"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -410,7 +410,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", akış 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "%s %s'den: "
@@ -555,7 +555,7 @@ msgstr "MLD Azaltma"
 msgid "unknown icmp type: %u"
 msgstr "bilinmeyen icmp türü: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "yerel hata"
 
@@ -564,12 +564,12 @@ msgstr "yerel hata"
 msgid "local error: message too long, mtu: %u"
 msgstr "yerel hata: mesaj çok uzun, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "%s'den icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -624,16 +624,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "paket çok kısa: %d bayt"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "%s'den: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "UYARI: soket filtresi kurulamadı"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "bilinmeyen protokol ailesi: %d"
@@ -676,76 +676,71 @@ msgstr "hatalı TOS değeri: %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "TOS bitlerinin ondalık değeri 0-255 aralığında olmalıdır: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "-4 veya -6 seçeneklerinden sadece biri belirtilebilir"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "-T veya -R seçeneklerinden sadece biri kullanılabilir"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "geçersiz zaman damgası türü: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "hatalı zaman aralığı"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "hatalı zaman aralığı: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "kopyalanamıyor: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "geçersiz kaynak adresi: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "ön yükleme 3'ten büyük bir değere ayarlanamıyor: %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "geçersiz -M argümanı: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "hatalı yanıt bekleme süresi"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "hatalı yanıt bekleme süresi: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr "UYARI: ters DNS çözümlemesi (PTR araması) devre dışı, -H ile zorlayın"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "UYARI: ident 0 => ham soket zorlanıyor"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "İçinde IPv4 eşlenen IPv6 adresi, IPv4 %s kullanılıyor"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr "geçersiz -s değeri: '%d': aralık dışında: 0 <= değer <= %d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -755,11 +750,11 @@ msgstr ""
 "kapsam kimliği kullanımını gerektirebilir => adres%%<arayüz-adı|kapsam-"
 "kimliği> kullanın"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "uyarı: QOS sockopts"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -767,20 +762,20 @@ msgstr ""
 "Genel yayına ping atmak istiyor musunuz? Öylese -b kullanın. Değilse, yerel "
 "güvenlik duvarı kurallarınızı gözden geçirin"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "UYARI: genel yayın adresine ping atılıyor\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "genel yayın ayarlanamıyor"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs başarısız"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -789,44 +784,44 @@ msgstr ""
 "kullanıcı için genel yayın ping için en düşük aralık >= %d ms olmalıdır, -i "
 "%s (veya daha yüksek) kullanın"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "genel yayın pingi parçalanmaz"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "UYARI: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "UYARI: çekirdek sürümünüz çok eski. Sorun yok."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "UYARI: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "UYARI: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "çok noktaya yayın geri dönüşü devre dışı bırakılamıyor"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "çok noktaya yayın yaşam süresi ayarlanamıyor"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "tek noktaya yayın yaşam süresi ayarlanamıyor"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) bayt veri.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -835,7 +830,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -844,12 +839,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(aynı rota)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -858,7 +853,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -867,27 +862,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld mutlak standart dışı"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld standart dışı"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld mutlak"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Kaydedilmeyen atlama: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -896,232 +891,232 @@ msgstr ""
 "\n"
 "bilinmeyen seçenek %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Yankı Yanıtı\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Ulaşılamayan Hedef Ağ\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Ulaşılamayan Hedef Ana Makine\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Ulaşılamayan Hedef Protokolü\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Ulaşılamayan Hedef Bağlantı Noktası\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Parçalanma (frag) gerekli ve DF ayarlandı (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Kaynak Rota Başarısız\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Bilinmeyen Hedef Ağ\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Bilinmeyen Hedef Ana Makine\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Yalıtılmış Kaynak Ana Makine\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Yasak Hedef Ağ\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Yasak Hedef Ana Makine\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Hizmet Türü için Ulaşılamayan Hedef Ağ\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Hizmet Türü için Ulaşılamayan Hedef Ana Makine\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Paket filtrelendi\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Öncelik İhlali\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Öncelik Kesintisi\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Ulaşılamayan Hedef, Hata Kodu: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Yavaşlatılmış Kaynak\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Ağ Yeniden Yönlendirme"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Ana Makine Yeniden Yönlendirme"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Hizmet Türü ve Ağ Yeniden Yönlendirme"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Hizmet Türü ve Ana Makine Yeniden Yönlendirme"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Yeniden Yönlendirme, Hata Kodu: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Yeni sonraki atlama: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Yankı İsteği\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Yaşam süresi aşıldı\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Parçalanma yeniden birleştirme zamanı aşıldı\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Süre aşıldı, Hata Kodu: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Parametre sorunu: işaretçi = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Zaman Damgası\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Zaman Damgası Yanıtı\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Bilgi İsteği\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Bilgi Yanıtı\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Adres Maskesi İsteği\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Adres Maskesi Yanıtı\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Hatalı ICMP türü: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "yerel hata: mesaj çok uzun, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "paket çok kısa(%d bayt), %s'den"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "%s'den: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(YANLIŞ SAĞLAMA TOPLAMI)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(YANLIŞ SAĞLAMA TOPLAMI)\n"
@@ -1569,6 +1564,10 @@ msgstr "%d geri "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen şu aralıkta olmalıdır: %d < değer <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "İçinde IPv4 eşlenen IPv6 adresi, IPv4 %s kullanılıyor"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <https://translate.fedoraproject.org/projects/"
@@ -149,9 +149,9 @@ msgstr "Інтерфейс «%s» є непридатним для аналіз�
 msgid "WARNING: using default broadcast address.\n"
 msgstr "Попередження: використовуємо типову адресу трансляції.\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "некоректний аргумент"
@@ -296,7 +296,7 @@ msgid "too long scope name"
 msgstr "надто довга назва області"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "не вдалося отримати місце у пам'яті"
 
@@ -350,7 +350,7 @@ msgstr ""
 "  subject-name=назва\n"
 "  subject-fqdn=назва\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "невідомий інтерфейс: %s"
@@ -359,7 +359,7 @@ msgstr "невідомий інтерфейс: %s"
 msgid "scope discrepancy among the nodes"
 msgstr "невідповідність областей між вузлами"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr ""
@@ -409,7 +409,7 @@ msgstr "не вдалося встановити мітку потоку"
 msgid "can't send flowinfo"
 msgstr "не вдалося надіслати відомості щодо потоку"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "ПІНГ %s (%s) "
@@ -419,7 +419,7 @@ msgstr "ПІНГ %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr ", потік 0x%05x, "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "з %s %s: "
@@ -564,7 +564,7 @@ msgstr "Спрощення MLD"
 msgid "unknown icmp type: %u"
 msgstr "невідомий тип icmp: %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "локальна помилка"
 
@@ -573,12 +573,12 @@ msgstr "локальна помилка"
 msgid "local error: message too long, mtu: %u"
 msgstr "локальна помилка: надто велике повідомлення, mtu: %u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "З %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -633,16 +633,16 @@ msgstr "; посл=%u;"
 msgid "packet too short: %d bytes"
 msgstr "надто короткий пакет: %d байтів"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "Від %s: "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "Попередження: не вдалося встановити фільтрування сокетів"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "невідоме сімейство протоколів: %d"
@@ -686,82 +686,77 @@ msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr ""
 "десяткове значення бітів TOS має належати до діапазону від 0 до 255: %d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "можна вказувати лише один із параметрів — -4 або -6"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "можна вказувати лише один із параметрів — -T або -R"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "некоректний тип часової позначки: %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "помилковий часовий інтервал"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "помилковий часовий інтервал: %s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "не вдалося скопіювати: %s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "некоректна адреса джерела: %s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr ""
 "неможливо встановити для попереднього завантаження значення, що перевищує 3: "
 "%d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "некоректний аргумент -M: %s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "помилковий час затягування"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "помилковий час затягування: %s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 "УВАГА: розв'язання зворотним DNS (пошук PTR) вимкнено, можна примусово "
 "увімкнути за допомогою -H"
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "УВАГА: ident 0 => примусово сокет без обробки"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr "Адреса IPv4 пов'язана із IPv6, використовуємо IPv4 %s"
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 "некоректне значення -s: «%d»: поза припустимим діапазоном: 0 <= значення <= "
 "%d"
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -771,11 +766,11 @@ msgstr ""
 "інтерфейсу або ідентифікатор області => користуйтеся таким: адреса%%<назва "
 "інтерфейсу|ідентифікатор області>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "попередження: sockopts QOS"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
@@ -783,20 +778,20 @@ msgstr ""
 "Хочете надіслати пінг трансляції? Скористайтеся -b. Якщо ні, перевірте, чи "
 "правильно вказано правила вашого локального брандмауера"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "УВАГА: перевірка пінгом адреси трансляції\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "не вдалося встановити трансляцію"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "помилка gatifaddrs"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
@@ -805,45 +800,45 @@ msgstr ""
 "мінімальний проміжок для неспрямованого трансляційного пінґу для користувача "
 "має бути >= %d мс, скористайтеся -i %s (або більшим значенням)"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "пінг трансляції не фрагментується"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "Попередження: setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "Попередження: ваше ядро є надто застарілим. Немає проблем."
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "Попередження: setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "Попередження: setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "неможливо вимкнути зворотну петлю неспрямованої трансляції"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "не вдалося встановити граничний час існування неспрямованої трансляції"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr ""
 "не вдалося встановити граничний час існування односпрямованої трансляції"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) байтів даних.\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -852,7 +847,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -861,12 +856,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(той самий маршрут)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -875,7 +870,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -884,27 +879,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld абсолютний нестандартний"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld нестандартний"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld абсолютний"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "Незаписаних перестрибувань: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -913,232 +908,232 @@ msgstr ""
 "\n"
 "невідомий параметр %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr "Vr HL TOS  Дов   Ід Пра  off TTL Про  cks      Дже      При Дані\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "Луна-відповідь\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "Мережа призначення недоступна\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "Вузол призначення недоступний\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "Протокол призначення недоступний\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "Порт призначення недоступний\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "Потрібна фрагментація і встановлено DF (mtu = %u)\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "Помилка маршрутизації до джерела\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "Невідома мережа призначення\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "Невідомий вузол призначення\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "Ізольований вузол джерела\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "Заборонена мережа призначення\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "Заборонений вузол призначення\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "Недоступна для типу служби мережа призначення\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "Недоступний для типу служби вузол призначення\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "Пакет відфільтровано\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "Порушення першості\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "Обрізання першості\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "Недоступне призначення, помилковий код: %d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "Обрив зв'язку з джерелом\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "Переспрямовування мережі"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "Переспрямовування вузла"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "Тип переспрямовування служби і мережі"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "Тип переспрямовування служби і вузла"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "Переспрямовування, помилковий код: %d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(Нове наступне перестрибування: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Луна-запит\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "Перевищено граничний час існування\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "Перевищено час повторного збирання фрагментів\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "Перевищено обмеження за часом, помилковий код: %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "Проблема із параметрами: вказівник = %u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "Часова позначка\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "Відповідь щодо часової позначки\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "Запит щодо відомостей\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "Відповідь щодо відомостей\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "Запит щодо маски адреси\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "Відповідь щодо маски адреси\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "Помилковий тип ICMP: %d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "локальна помилка: надто велике повідомлення, mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "пакет є надто коротким (%d байтів), отримано з %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "З %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(ПОМИЛКОВА КОНТРОЛЬНА СУМА)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(ПОМИЛКОВА КОНТРОЛЬНА СУМА)\n"
@@ -1591,6 +1586,10 @@ msgstr "назад %d "
 #, c-format
 msgid "pktlen must be within: %d < value <= %d"
 msgstr "pktlen має задовольняти таку нерівністю: %d < значення <= %d"
+
+#, c-format
+#~ msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
+#~ msgstr "Адреса IPv4 пов'язана із IPv6, використовуємо IPv4 %s"
 
 #, c-format
 #~ msgid "local error: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-18 19:07+0200\n"
+"POT-Creation-Date: 2024-11-15 17:30+0100\n"
 "PO-Revision-Date: 2023-12-20 15:03+0000\n"
 "Last-Translator: yangyangdaji <1504305527@qq.com>\n"
 "Language-Team: Chinese (Simplified) <https://translate.fedoraproject.org/"
@@ -146,9 +146,9 @@ msgstr "网络接口 “%s” 不适用 ARP\n"
 msgid "WARNING: using default broadcast address.\n"
 msgstr "警告：使用默认广播地址。\n"
 
-#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:409 ping/ping.c:456
-#: ping/ping.c:508 ping/ping.c:516 ping/ping.c:560 ping/ping.c:563
-#: ping/ping.c:566 ping/ping.c:580 tracepath.c:474 tracepath.c:477
+#: arping.c:905 arping.c:908 arping.c:911 ping/ping.c:408 ping/ping.c:455
+#: ping/ping.c:507 ping/ping.c:515 ping/ping.c:559 ping/ping.c:562
+#: ping/ping.c:565 ping/ping.c:579 tracepath.c:474 tracepath.c:477
 #: tracepath.c:480 tracepath.c:502
 msgid "invalid argument"
 msgstr "无效参数"
@@ -289,7 +289,7 @@ msgid "too long scope name"
 msgstr "作用域名称太长"
 
 #: ping/node_info.c:347 ping/node_info.c:389 ping/ping6_common.c:308
-#: ping/ping.c:1068
+#: ping/ping.c:1059
 msgid "memory allocation failed"
 msgstr "内存分配错误"
 
@@ -343,7 +343,7 @@ msgstr ""
 "  subject-name=name\n"
 "  subject-fqdn=name\n"
 
-#: ping/ping6_common.c:99 ping/ping.c:756
+#: ping/ping6_common.c:99 ping/ping.c:747
 #, c-format
 msgid "unknown iface: %s"
 msgstr "未知界面：%s"
@@ -352,7 +352,7 @@ msgstr "未知界面：%s"
 msgid "scope discrepancy among the nodes"
 msgstr "节点之间的范围差异"
 
-#: ping/ping6_common.c:225 ping/ping.c:926
+#: ping/ping6_common.c:225 ping/ping.c:917
 #, c-format
 msgid "Warning: source address might be selected on device other than: %s"
 msgstr "警告：可能在除以下设备之外的设备上选择了源地址：%s"
@@ -396,7 +396,7 @@ msgstr "无法设置流标签"
 msgid "can't send flowinfo"
 msgstr "无法发送流信息"
 
-#: ping/ping6_common.c:397 ping/ping.c:1070
+#: ping/ping6_common.c:397 ping/ping.c:1061
 #, c-format
 msgid "PING %s (%s) "
 msgstr "PING %s (%s) "
@@ -406,7 +406,7 @@ msgstr "PING %s (%s) "
 msgid ", flow 0x%05x, "
 msgstr "，流量 0x%05x， "
 
-#: ping/ping6_common.c:404 ping/ping.c:1072
+#: ping/ping6_common.c:404 ping/ping.c:1063
 #, c-format
 msgid "from %s %s: "
 msgstr "来自 %s %s "
@@ -551,7 +551,7 @@ msgstr "组播组退出"
 msgid "unknown icmp type: %u"
 msgstr "未知的 ICMP 类型： %u"
 
-#: ping/ping6_common.c:547 ping/ping.c:1489
+#: ping/ping6_common.c:547 ping/ping.c:1480
 msgid "local error"
 msgstr "本地错误"
 
@@ -560,12 +560,12 @@ msgstr "本地错误"
 msgid "local error: message too long, mtu: %u"
 msgstr "本地错误：消息太长，MTU：%u"
 
-#: ping/ping6_common.c:571 ping/ping.c:1525
+#: ping/ping6_common.c:571 ping/ping.c:1516
 #, c-format
 msgid "From %s icmp_seq=%u "
 msgstr "来自 %s icmp_seq=%u "
 
-#: ping/ping6_common.c:677 ping/ping.c:1639
+#: ping/ping6_common.c:677 ping/ping.c:1630
 #, c-format
 msgid " icmp_seq=%u"
 msgstr " icmp_seq=%u"
@@ -620,16 +620,16 @@ msgstr "; seq=%u;"
 msgid "packet too short: %d bytes"
 msgstr "过短的包: %d 字节"
 
-#: ping/ping6_common.c:923 ping/ping.c:1768
+#: ping/ping6_common.c:923 ping/ping.c:1759
 #, c-format
 msgid "From %s: "
 msgstr "来自%s ： "
 
-#: ping/ping6_common.c:964 ping/ping.c:1873
+#: ping/ping6_common.c:964 ping/ping.c:1864
 msgid "WARNING: failed to install socket filter"
 msgstr "警告：无法安装套接字过滤器"
 
-#: ping/ping.c:103 ping/ping.c:733
+#: ping/ping.c:103 ping/ping.c:724
 #, c-format
 msgid "unknown protocol family: %d"
 msgstr "未知协议系列： %d"
@@ -672,76 +672,71 @@ msgstr "错误的 TOS 值： %s"
 msgid "the decimal value of TOS bits must be in range 0-255: %d"
 msgstr "TOS 位的十进制值必须在 0-255 范围内：%d"
 
-#: ping/ping.c:399 ping/ping.c:433
+#: ping/ping.c:398 ping/ping.c:432
 msgid "only one -4 or -6 option may be specified"
 msgstr "只接受参数 -4 或 -6 中的一个"
 
-#: ping/ping.c:414 ping/ping.c:419
+#: ping/ping.c:413 ping/ping.c:418
 msgid "only one of -T or -R may be used"
 msgstr "只能使用 -T 或 -R 中的一个"
 
-#: ping/ping.c:428
+#: ping/ping.c:427
 #, c-format
 msgid "invalid timestamp type: %s"
 msgstr "时间戳类型无效： %s"
 
-#: ping/ping.c:474
+#: ping/ping.c:473
 msgid "bad timing interval"
 msgstr "时序间隔错误"
 
-#: ping/ping.c:476
+#: ping/ping.c:475
 #, c-format
 msgid "bad timing interval: %s"
 msgstr "时序间隔错误：%s"
 
-#: ping/ping.c:487
+#: ping/ping.c:486
 #, c-format
 msgid "cannot copy: %s"
 msgstr "无法打开：%s"
 
-#: ping/ping.c:496
+#: ping/ping.c:495
 #, c-format
 msgid "invalid source address: %s"
 msgstr "源地址无效：%s"
 
-#: ping/ping.c:510
+#: ping/ping.c:509
 #, c-format
 msgid "cannot set preload to value greater than 3: %d"
 msgstr "不能将 preload 设置到 3 以上的 %d"
 
-#: ping/ping.c:529
+#: ping/ping.c:528
 #, c-format
 msgid "invalid -M argument: %s"
 msgstr "无效参数：%s"
 
-#: ping/ping.c:586
+#: ping/ping.c:585
 msgid "bad linger time"
 msgstr "徘徊时间无效"
 
-#: ping/ping.c:588
+#: ping/ping.c:587
 #, c-format
 msgid "bad linger time: %s"
 msgstr "徘徊时间无效：%s"
 
-#: ping/ping.c:600
+#: ping/ping.c:599
 msgid "WARNING: reverse DNS resolution (PTR lookup) disabled, enforce with -H"
 msgstr ""
 
-#: ping/ping.c:619
+#: ping/ping.c:618
 msgid "WARNING: ident 0 => forcing raw socket"
 msgstr "警告：标识 0 => 强制使用原始套接字"
 
-#: ping/ping.c:629
-#, c-format
-msgid "IPv4-Mapped-in-IPv6 address, using IPv4 %s"
-msgstr ""
-
-#: ping/ping.c:673
+#: ping/ping.c:664
 #, c-format
 msgid "invalid -s value: '%d': out of range: 0 <= value <= %d"
 msgstr ""
 
-#: ping/ping.c:701
+#: ping/ping.c:692
 #, c-format
 msgid ""
 "Warning: IPv6 link-local address on ICMP datagram socket may require ifname "
@@ -750,74 +745,74 @@ msgstr ""
 "警告：ICMP 数据报套接字上的 IPv6 链路本地地址可能需要 ifname 或作用域 ID => "
 "使用：地址%%<ifname|scope-id>"
 
-#: ping/ping.c:878
+#: ping/ping.c:869
 msgid "warning: QOS sockopts"
 msgstr "警告：QOS 套接字选项"
 
-#: ping/ping.c:889
+#: ping/ping.c:880
 msgid ""
 "Do you want to ping broadcast? Then -b. If not, check your local firewall "
 "rules"
 msgstr "您想要 ping 广播地址吗？若是则加上参数 -b，否则检查你的本地防火墙规则"
 
-#: ping/ping.c:890
+#: ping/ping.c:881
 #, c-format
 msgid "WARNING: pinging broadcast address\n"
 msgstr "警告：正在 ping 广播地址\n"
 
-#: ping/ping.c:893 ping/ping.c:1048
+#: ping/ping.c:884 ping/ping.c:1039
 msgid "cannot set broadcasting"
 msgstr "不能设置广播"
 
-#: ping/ping.c:914
+#: ping/ping.c:905
 msgid "gatifaddrs failed"
 msgstr "gatifaddrs 失败"
 
-#: ping/ping.c:942
+#: ping/ping.c:933
 #, c-format
 msgid ""
 "minimal interval for broadcast ping for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr "用户广播 ping 的最小间隔必须 >= %d ms，使用 -i %s （或更高）"
 
-#: ping/ping.c:947
+#: ping/ping.c:938
 msgid "broadcast ping does not fragment"
 msgstr "广播 ping 不分段"
 
-#: ping/ping.c:977
+#: ping/ping.c:968
 msgid "WARNING: setsockopt(ICMP_FILTER)"
 msgstr "警告：setsockopt(ICMP_FILTER)"
 
-#: ping/ping.c:982
+#: ping/ping.c:973
 msgid "WARNING: your kernel is veeery old. No problems."
 msgstr "警告：您的内核非常旧。没有其他问题。"
 
-#: ping/ping.c:986
+#: ping/ping.c:977
 msgid "WARNING: setsockopt(IP_RECVTTL)"
 msgstr "警告：setsockopt(IP_RECVTTL)"
 
-#: ping/ping.c:988
+#: ping/ping.c:979
 msgid "WARNING: setsockopt(IP_RETOPTS)"
 msgstr "警告：setsockopt(IP_RETOPTS)"
 
-#: ping/ping.c:1054
+#: ping/ping.c:1045
 msgid "cannot disable multicast loopback"
 msgstr "无法禁用组播环回"
 
-#: ping/ping.c:1059
+#: ping/ping.c:1050
 msgid "cannot set multicast time-to-live"
 msgstr "不能设置多播 TTL"
 
-#: ping/ping.c:1061
+#: ping/ping.c:1052
 msgid "cannot set unicast time-to-live"
 msgstr "不能设置单拨的 TTL"
 
-#: ping/ping.c:1073
+#: ping/ping.c:1064
 #, c-format
 msgid "%d(%d) bytes of data.\n"
 msgstr "%d(%d) 字节的数据。\n"
 
-#: ping/ping.c:1105
+#: ping/ping.c:1096
 #, c-format
 msgid ""
 "\n"
@@ -826,7 +821,7 @@ msgstr ""
 "\n"
 "NOP"
 
-#: ping/ping.c:1116
+#: ping/ping.c:1107
 #, c-format
 msgid ""
 "\n"
@@ -835,12 +830,12 @@ msgstr ""
 "\n"
 "%cSRR: "
 
-#: ping/ping.c:1154
+#: ping/ping.c:1145
 #, c-format
 msgid "\t(same route)"
 msgstr "\t(同一路由)"
 
-#: ping/ping.c:1159
+#: ping/ping.c:1150
 #, c-format
 msgid ""
 "\n"
@@ -849,7 +844,7 @@ msgstr ""
 "\n"
 "RR: "
 
-#: ping/ping.c:1195
+#: ping/ping.c:1186
 #, c-format
 msgid ""
 "\n"
@@ -858,27 +853,27 @@ msgstr ""
 "\n"
 "TS: "
 
-#: ping/ping.c:1227
+#: ping/ping.c:1218
 #, c-format
 msgid "\t%ld absolute not-standard"
 msgstr "\t%ld 绝对非标准"
 
-#: ping/ping.c:1229
+#: ping/ping.c:1220
 #, c-format
 msgid "\t%ld not-standard"
 msgstr "\t%ld 非标准"
 
-#: ping/ping.c:1233
+#: ping/ping.c:1224
 #, c-format
 msgid "\t%ld absolute"
 msgstr "\t%ld 绝对"
 
-#: ping/ping.c:1244
+#: ping/ping.c:1235
 #, c-format
 msgid "Unrecorded hops: %d\n"
 msgstr "未记录的跃点数: %d\n"
 
-#: ping/ping.c:1248
+#: ping/ping.c:1239
 #, c-format
 msgid ""
 "\n"
@@ -887,233 +882,233 @@ msgstr ""
 "\n"
 "未知选项： %x"
 
-#: ping/ping.c:1268
+#: ping/ping.c:1259
 #, c-format
 msgid "Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst Data\n"
 msgstr ""
 "Vr HL TOS  Len   ID 标记  关闭 TTL Pro  cks      源位置      目标数据\n"
 
-#: ping/ping.c:1269
+#: ping/ping.c:1260
 #, c-format
 msgid " %1x  %1x  %02x %04x %04x"
 msgstr " %1x  %1x  %02x %04x %04x"
 
-#: ping/ping.c:1271
+#: ping/ping.c:1262
 #, c-format
 msgid "   %1x %04x"
 msgstr "   %1x %04x"
 
-#: ping/ping.c:1273
+#: ping/ping.c:1264
 #, c-format
 msgid "  %02x  %02x %04x"
 msgstr "  %02x  %02x %04x"
 
-#: ping/ping.c:1289
+#: ping/ping.c:1280
 #, c-format
 msgid "Echo Reply\n"
 msgstr "回声应答\n"
 
-#: ping/ping.c:1295
+#: ping/ping.c:1286
 #, c-format
 msgid "Destination Net Unreachable\n"
 msgstr "目标网络不可达\n"
 
-#: ping/ping.c:1298
+#: ping/ping.c:1289
 #, c-format
 msgid "Destination Host Unreachable\n"
 msgstr "目标主机不可达\n"
 
-#: ping/ping.c:1301
+#: ping/ping.c:1292
 #, c-format
 msgid "Destination Protocol Unreachable\n"
 msgstr "目标协议不可达\n"
 
-#: ping/ping.c:1304
+#: ping/ping.c:1295
 #, c-format
 msgid "Destination Port Unreachable\n"
 msgstr "目标端口不可达\n"
 
-#: ping/ping.c:1307
+#: ping/ping.c:1298
 #, c-format
 msgid "Frag needed and DF set (mtu = %u)\n"
 msgstr "需要分段但是设置了 DF （mtu = %u）\n"
 
-#: ping/ping.c:1310
+#: ping/ping.c:1301
 #, c-format
 msgid "Source Route Failed\n"
 msgstr "源路由失败\n"
 
-#: ping/ping.c:1313
+#: ping/ping.c:1304
 #, c-format
 msgid "Destination Net Unknown\n"
 msgstr "目标网络未知\n"
 
-#: ping/ping.c:1316
+#: ping/ping.c:1307
 #, c-format
 msgid "Destination Host Unknown\n"
 msgstr "目标主机未知\n"
 
-#: ping/ping.c:1319
+#: ping/ping.c:1310
 #, c-format
 msgid "Source Host Isolated\n"
 msgstr "源主机隔离\n"
 
-#: ping/ping.c:1322
+#: ping/ping.c:1313
 #, c-format
 msgid "Destination Net Prohibited\n"
 msgstr "目标网络被禁止。\n"
 
-#: ping/ping.c:1325
+#: ping/ping.c:1316
 #, c-format
 msgid "Destination Host Prohibited\n"
 msgstr "目标主机被禁止\n"
 
-#: ping/ping.c:1328
+#: ping/ping.c:1319
 #, c-format
 msgid "Destination Net Unreachable for Type of Service\n"
 msgstr "对于此 ToS 而言目标网络不可达\n"
 
-#: ping/ping.c:1331
+#: ping/ping.c:1322
 #, c-format
 msgid "Destination Host Unreachable for Type of Service\n"
 msgstr "对于此 ToS 而言目标主机不可达\n"
 
-#: ping/ping.c:1334
+#: ping/ping.c:1325
 #, c-format
 msgid "Packet filtered\n"
 msgstr "数据包被过滤\n"
 
-#: ping/ping.c:1337
+#: ping/ping.c:1328
 #, c-format
 msgid "Precedence Violation\n"
 msgstr "优先级冲突\n"
 
-#: ping/ping.c:1340
+#: ping/ping.c:1331
 #, c-format
 msgid "Precedence Cutoff\n"
 msgstr "优先级冲突\n"
 
-#: ping/ping.c:1343
+#: ping/ping.c:1334
 #, c-format
 msgid "Dest Unreachable, Bad Code: %d\n"
 msgstr "目标不可达，错误代码：%d\n"
 
-#: ping/ping.c:1350
+#: ping/ping.c:1341
 #, c-format
 msgid "Source Quench\n"
 msgstr "源淬火\n"
 
-#: ping/ping.c:1357
+#: ping/ping.c:1348
 #, c-format
 msgid "Redirect Network"
 msgstr "重定向网络"
 
-#: ping/ping.c:1360
+#: ping/ping.c:1351
 #, c-format
 msgid "Redirect Host"
 msgstr "重定向主机"
 
-#: ping/ping.c:1363
+#: ping/ping.c:1354
 #, c-format
 msgid "Redirect Type of Service and Network"
 msgstr "重定向服务和网络类型"
 
-#: ping/ping.c:1366
+#: ping/ping.c:1357
 #, c-format
 msgid "Redirect Type of Service and Host"
 msgstr "重定向服务和主机类型"
 
-#: ping/ping.c:1369
+#: ping/ping.c:1360
 #, c-format
 msgid "Redirect, Bad Code: %d"
 msgstr "重定向，错误代码：%d"
 
-#: ping/ping.c:1380
+#: ping/ping.c:1371
 #, c-format
 msgid "(New nexthop: %s)\n"
 msgstr "(新的下一跳: %s)\n"
 
-#: ping/ping.c:1386
+#: ping/ping.c:1377
 #, c-format
 msgid "Echo Request\n"
 msgstr "Echo 请求\n"
 
-#: ping/ping.c:1392
+#: ping/ping.c:1383
 #, c-format
 msgid "Time to live exceeded\n"
 msgstr "超过生存时间\n"
 
-#: ping/ping.c:1395
+#: ping/ping.c:1386
 #, c-format
 msgid "Frag reassembly time exceeded\n"
 msgstr "分段重建时间超时\n"
 
-#: ping/ping.c:1398
+#: ping/ping.c:1389
 #, c-format
 msgid "Time exceeded, Bad Code: %d\n"
 msgstr "超时，错误代码： %d\n"
 
-#: ping/ping.c:1405
+#: ping/ping.c:1396
 #, c-format
 msgid "Parameter problem: pointer = %u\n"
 msgstr "参数问题：指针=%u\n"
 
-#: ping/ping.c:1411
+#: ping/ping.c:1402
 #, c-format
 msgid "Timestamp\n"
 msgstr "时间戳\n"
 
-#: ping/ping.c:1415
+#: ping/ping.c:1406
 #, c-format
 msgid "Timestamp Reply\n"
 msgstr "时间戳回复\n"
 
-#: ping/ping.c:1419
+#: ping/ping.c:1410
 #, c-format
 msgid "Information Request\n"
 msgstr "信息请求\n"
 
-#: ping/ping.c:1423
+#: ping/ping.c:1414
 #, c-format
 msgid "Information Reply\n"
 msgstr "应答信息\n"
 
-#: ping/ping.c:1428
+#: ping/ping.c:1419
 #, c-format
 msgid "Address Mask Request\n"
 msgstr "地址掩码请求\n"
 
-#: ping/ping.c:1433
+#: ping/ping.c:1424
 #, c-format
 msgid "Address Mask Reply\n"
 msgstr "地址掩码应答\n"
 
-#: ping/ping.c:1437
+#: ping/ping.c:1428
 #, c-format
 msgid "Bad ICMP type: %d\n"
 msgstr "错误的 ICMP 类型：%d\n"
 
-#: ping/ping.c:1491
+#: ping/ping.c:1482
 #, c-format
 msgid "local error: message too long, mtu=%u"
 msgstr "本地错误：消息太长，mtu=%u"
 
-#: ping/ping.c:1664
+#: ping/ping.c:1655
 #, c-format
 msgid "packet too short (%d bytes) from %s"
 msgstr "过短的包 (%d 字节) 来自 %s"
 
-#: ping/ping.c:1743
+#: ping/ping.c:1734
 #, c-format
 msgid "From %s: icmp_seq=%u "
 msgstr "来自 %s: icmp_seq=%u "
 
-#: ping/ping.c:1746
+#: ping/ping.c:1737
 #, c-format
 msgid "(BAD CHECKSUM)"
 msgstr "(CHECKSUM 错误)"
 
-#: ping/ping.c:1770
+#: ping/ping.c:1761
 #, c-format
 msgid "(BAD CHECKSUM)\n"
 msgstr "(CHECKSUM 错误)\n"


### PR DESCRIPTION
This reverts commit 8ed7ffc999e2a541e06ee48faf26a323dfe487c2.

This is an incomplete implementation. While there are two attempts (PR#562 [1] PR#562 [2] and PR#563 [3]) to fix it, it's probably not a good idea to support IPv4-Mapped-in-IPv6 target addresses.

There were concerns [4] about supporting this when discussion on BusyBox mailing list about patch bringing this functionality to BusyBox ping implementation:

* ping is a low-level diagnostic tool, maybe it's not good to assume things like this, because IPv4-mapped IPv6 address format is not supported by raw sockets
* it's not clear how -4 -6 switches should behave

Although inetutils ping at least partly supports the feature [5]:

- explicit ipv4 ping:
```
% ping -c1 ::ffff:127.0.0.1
PING ::ffff:127.0.0.1 (127.0.0.1): 56 data bytes
64 bytes from 127.0.0.1: icmp_seq=0 ttl=64 time=0,100 ms
```

- explicit ipv6 ping:
```
% ping6 -c1 ::ffff:127.0.0.1
PING ::ffff:127.0.0.1 (::ffff:127.0.0.1): 56 data bytes
./ping/ping6: sending packet: Network is unreachable
```

Because also fping did not want to support it [6], let's revert the feature.

[1] https://github.com/iputils/iputils/pull/561
[2] https://github.com/iputils/iputils/pull/563
[3] https://github.com/iputils/iputils/pull/562
[4] https://lists.busybox.net/pipermail/busybox/2024-October/090975.html
[5] https://lists.busybox.net/pipermail/busybox/2024-October/090985.html
[6] https://github.com/schweikert/fping/pull/356
