### PR TITLE
Fix ping man page syntax error

### DIFF
--- a/doc/ping.xml
+++ b/doc/ping.xml
@@ -790,9 +790,9 @@ xml:id="man.ping">
     <info>
       <title>ENVIRONMENT</title>
     </info>
-	<emphasis remap="I">IPUTILS_PING_PTR_LOOKUP</emphasis> environment
-	variable set to 0 disable reverse DNS resolution (PTR lookup) by default.
-	It will be overrided by <option>-H</option> or <option>-n</option> option.
+    <para><emphasis remap="I">IPUTILS_PING_PTR_LOOKUP</emphasis> environment
+    variable set to 0 disable reverse DNS resolution (PTR lookup) by default.
+    It will be overrided by <option>-H</option> or <option>-n</option> option.</para>
   </refsection>
 
   <refsection xml:id="exit_status">


### PR DESCRIPTION
Hi, 

The ping manpage got an addition in september to document the IPUTILS_PING_PTR_LOOKUP environment variable. The new section that was added does not put it's text in a <para> tag, this caused the next section not to be treated as such.

![2024-11-18-16-10-09](https://github.com/user-attachments/assets/491af868-86f5-4fca-9802-7814154dcf25)

(It was also indented with tabs instead of spaces like the rest of the document so I changed that as well)