### PR TITLE
tracepath: Cleanup min value of -l

### DIFF
--- a/tracepath.c
+++ b/tracepath.c
@@ -471,7 +471,7 @@ int main(int argc, char **argv)
 			ctl.show_both = 1;
 			break;
 		case 'l':
-			ctl.mtu = strtol_or_err(optarg, _("invalid argument"), ctl.overhead, INT_MAX);
+			ctl.mtu = strtol_or_err(optarg, _("invalid argument"), 0, INT_MAX);
 			break;
 		case 'm':
 			ctl.max_hops = strtol_or_err(optarg, _("invalid argument"), 0, MAX_HOPS_LIMIT);


### PR DESCRIPTION
`ctl.overhead` when used as a minimal value in `strtol_or_err()` haven't been set, it's still set to its initial value of zero. Using it is not an error, but it's confusing. Use 0 as in other `strtol_or_err()` use in `getopts()`.

Link: https://github.com/iputils/iputils/pull/569#issuecomment-2512779642
Fixes: 5562b6f ("tracepath: borrow everything good from tracepath6")
Suggested-by: Noah Meyerhans <noahm@debian.org>
Signed-off-by: Petr Vorel <pvorel@suse.cz>