### PR TITLE
Reduce duplicity in translation strings

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -822,19 +822,32 @@ restamp:
 			return 1;
 		}
 		if (rts->timing) {
-			if (rts->opt_rtt_precision)
-				printf(_(" time=%ld.%03ld ms"), triptime / 1000, triptime % 1000);
-			else if (triptime >= 100000 - 50)
-				printf(_(" time=%ld ms"), (triptime + 500) / 1000);
-			else if (triptime >= 10000 - 5)
-				printf(_(" time=%ld.%01ld ms"), (triptime + 50) / 1000,
-				       ((triptime + 50) % 1000) / 100);
-			else if (triptime >= 1000)
-				printf(_(" time=%ld.%02ld ms"), (triptime + 5) / 1000,
-				       ((triptime + 5) % 1000) / 10);
-			else
-				printf(_(" time=%ld.%03ld ms"), triptime / 1000,
-				       triptime % 1000);
+			char *fmt;
+			char fmt2[30];
+			long int num, dec = 0;
+
+			if (rts->opt_rtt_precision) {
+				fmt = "%ld.%03ld";
+				num = triptime / 1000;
+				dec = triptime % 1000;
+			} else if (triptime >= 100000 - 50) {
+				fmt = "%ld";
+				num = (triptime + 500) / 1000;
+			} else if (triptime >= 10000 - 5) {
+				fmt = "%ld.%01ld";
+				num = (triptime + 50) / 1000;
+				dec = ((triptime + 50) % 1000) / 100;
+			} else if (triptime >= 1000) {
+				fmt = "%ld.%02ld";
+				num = (triptime + 5) / 1000;
+				dec = ((triptime + 5) % 1000) / 10;
+			} else {
+				fmt = "%ld.%03ld";
+				num = triptime / 1000;
+				dec = triptime % 1000;
+			}
+			snprintf(fmt2, sizeof(fmt2), _(" time=%s ms"), fmt);
+			printf(fmt2, num, dec);
 		}
 
 		if (dupflag && (!multicast || rts->opt_verbose))

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-28 15:00+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech <https://translate.fedoraproject.org/projects/iputils/"
@@ -1324,42 +1324,27 @@ msgstr " TTL=%d"
 msgid " (truncated)\n"
 msgstr " (zkráceno)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " čas=%ld,%03ld ms"
+msgid " time=%s ms"
+msgstr " čas=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " čas=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " čas=%ld,%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " čas=%ld,%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUPL!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (CHYBNÝ KONTROLNÍ SOUČET!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ODLIŠNÁ ADRESA!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1368,67 +1353,67 @@ msgstr ""
 "\n"
 "nesprávná data na bajtu č. %d – měla by být 0x%x, ale jsou 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- Statistika pingů na %s ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld paketů odesláno, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld přijato"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld duplikátů"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld poškozených"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld chyb"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% ztráta paketů"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", čas %llu ms"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "RTT min/prům/max/std.odch = %ld,%03ld/%lu,%03ld/%ld,%03ld/%ld,%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%sroura %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sIPG/klouz.prům %d,%03d/%d,%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld paketů, %d%% ztráta"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/prům/klouz.prům/max = %ld,%03ld/%lu,%03ld/%d,%03d/%ld,%03ld ms"

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-11-04 17:56+0000\n"
 "Last-Translator: Marek Küthe <m.k@mk16.de>\n"
 "Language-Team: German <https://translate.fedoraproject.org/projects/iputils/"
@@ -1291,8 +1291,8 @@ msgid ""
 "cannot flood, minimal interval for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr ""
-"kann nicht fluten; Mindestintervall für Nutzer muss >= %d ms sein, verwende -"
-"i %s (oder höher)"
+"kann nicht fluten; Mindestintervall für Nutzer muss >= %d ms sein, verwende "
+"-i %s (oder höher)"
 
 #: ping/ping_common.c:504
 #, c-format
@@ -1328,42 +1328,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (abgeschnitten)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " Zeit=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " Zeit=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " Zeit=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " Zeit=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " Zeit=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (FALSCHE PRÜFSUMME!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ANDERE ADRESSE!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1372,67 +1357,67 @@ msgstr ""
 "\n"
 "falsches Datenbyte #%d sollte 0x%x sein, aber war 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s Ping-Statistiken ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld Pakete übertragen, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld empfangen"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld Duplikate"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ",+%ld beschädigt"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld Fehler"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% Paketverlust"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", Zeit %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%spipe %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld Pakete, %d%% Verlust"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-11-10 02:02+0000\n"
 "Last-Translator: Emilio Herrera <ehespinosa57@gmail.com>\n"
 "Language-Team: Spanish <https://translate.fedoraproject.org/projects/iputils/"
@@ -1202,109 +1202,94 @@ msgstr ""
 msgid " (truncated)\n"
 msgstr ""
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
+msgid " time=%s ms"
 msgstr ""
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr ""
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr ""
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr ""
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr ""
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr ""
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr ""
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
 "wrong data byte #%d should be 0x%x but was 0x%x"
 msgstr ""
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr ""
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr ""
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr ""
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ""
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ""
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ""
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ""
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ""
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr ""
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr ""
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr ""
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
-"PO-Revision-Date: 2024-12-19 11:38+0000\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
+"PO-Revision-Date: 2024-10-26 18:38+0000\n"
 "Last-Translator: Ricky Tigg <ricky.tigg@gmail.com>\n"
 "Language-Team: Finnish <https://translate.fedoraproject.org/projects/iputils/"
 "iputils/fi/>\n"
@@ -1316,42 +1316,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (typistetty)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " aika=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " aika=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " aika=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " aika=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " aika=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (Kaksoiskappale!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (Kelvoton tarkistussumma!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (Eri osoite!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1360,68 +1345,68 @@ msgstr ""
 "\n"
 "väärän datatavun #%d pitäisi olla 0x%x, mutta oli 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "-- %s ping-tilastot --\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld paketteja lähetetty, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld otettu vastaan"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld kaksoiskappaletta"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld vioittuneet"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld virhettä"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g %% pakettihäviö"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", aika %llu ms"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 "rtt min/keskiarvo/maks/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%spipe %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld pakettia, %d %% häviö"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/keskiarvo/ewma/maks = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Léane GRASSER <leane.grasser@proton.me>\n"
 "Language-Team: French <https://translate.fedoraproject.org/projects/iputils/"
@@ -1338,42 +1338,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (tronqué)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " temps=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " temps=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " temps=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " temps=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " temps=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUPLIQUÉ !)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (MAUVAISE SOMME DE CONTRÔLE !)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ADRESSE DIFFÉRENTE !)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1382,67 +1367,67 @@ msgstr ""
 "\n"
 "octet de données incorrect #%d devrait être 0x%x mais était 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- statistiques ping %s ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld paquets transmis, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld reçus"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld dupliqués"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld corrompus"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld erreurs"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g %% paquets perdus"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", temps %llu ms"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt min/moy/max/mdev = %ld,%03ld/%lu,%03ld/%ld,%03ld/%ld,%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%s tuyau %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%s ipg/mmpe %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld paquets, %d %% perdus"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/moy/mmpe/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.fedoraproject.org/projects/"
@@ -364,8 +364,8 @@ msgid ""
 "minimal interval for multicast ping for user must be >= %d ms, use -i %s (or "
 "higher)"
 msgstr ""
-"interval minimum bagi ping multicast untuk pengguna harus >= %d ms, gunakan -"
-"i %s (atau lebih tinggi)"
+"interval minimum bagi ping multicast untuk pengguna harus >= %d ms, gunakan "
+"-i %s (atau lebih tinggi)"
 
 #: ping/ping6_common.c:271
 msgid "multicast ping does not fragment"
@@ -1321,42 +1321,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (terpotong)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " waktu=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " waktu=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " waktu=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " waktu=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " waktu=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (BAD CHECKSUM!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ALAMAT LAIN!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1365,67 +1350,67 @@ msgstr ""
 "\n"
 "kesalahan byte data #%d harusnya 0x%x bukan 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- statistik ping %s ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld paket dikirim, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld diterima"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld duplikat"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld korup"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld error"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% paket hilang"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", waktu %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%spipe %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld paket, %d%% loss"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/iputils.pot
+++ b/po/iputils.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1178,109 +1178,94 @@ msgstr ""
 msgid " (truncated)\n"
 msgstr ""
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
+msgid " time=%s ms"
 msgstr ""
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr ""
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr ""
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr ""
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr ""
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr ""
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr ""
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
 "wrong data byte #%d should be 0x%x but was 0x%x"
 msgstr ""
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr ""
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr ""
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr ""
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ""
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ""
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ""
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ""
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ""
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr ""
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr ""
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr ""
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils 20161105\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-09-03 06:23+0000\n"
 "Last-Translator: Weblate Translation Memory <noreply-mt-weblate-translation-"
 "memory@weblate.org>\n"
@@ -1355,42 +1355,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (切り詰められました)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " 時間=%ld.%03ldミリ秒"
+msgid " time=%s ms"
+msgstr " 時間=%s ミリ秒"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " 時間=%ld ミリ秒"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " 時間=%ld.%01ldミリ秒"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " 時間=%ld.%02ldミリ秒"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (重複!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (チェックサム異常!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (アドレス相違!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1399,68 +1384,68 @@ msgstr ""
 "\n"
 "誤りデータバイト #%d. 正しい値: 0x%x 返り値: 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s ping 統計 ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "送信パケット数 %ld, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "受信パケット数 %ld"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld 重複"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld 破損"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld エラー"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", パケット損失 %g%%"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", 時間 %lluミリ秒"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 "rtt 最小/平均/最大/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ldミリ秒"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%spipe %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03dミリ秒"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld パケット, パケット損失 %d%%"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", 最小/平均/ewma/最大 = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ldミリ秒"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <https://translate.fedoraproject.org/projects/"
@@ -1336,42 +1336,27 @@ msgstr " ttl =%d"
 msgid " (truncated)\n"
 msgstr " (მოკვეცილია)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " დრო=%ld.%03ld მწმ"
+msgid " time=%s ms"
+msgstr " დრო=%s მწმ"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " დრო = %ld მწმ"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " დრო=%ld.%01ld მწმ"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " დრო=%ld.%02ld მწმ"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (ცუდი საკონტროლო ჯამი!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (განსხვავებული მისამართი)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1380,67 +1365,67 @@ msgstr ""
 "\n"
 "მონაცემების არასწორი ბაიტი #%d უნდა იყოს 0ხ%x მაგრამ იყო 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s-ის პინგის სტატისტიკა ----\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "გადაცემულია %ld პაკეტი, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "მიღებულია %ld"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld ასლი"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld გაფუჭებული"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld შეცდომა"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% პაკეტი დაიკარგა"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", დრო %lluმწმ"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt მინ/საშ/მაქს/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld მწმ"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%s არხი %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d მწმ"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld პაკეტი, %d%% დაკარგულია"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", მინ/საშ/ewma/მაქს = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld მწმ"

--- a/po/kab.po
+++ b/po/kab.po
@@ -6,10 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
-"Last-Translator: ButterflyOfFire <butterflyoffire@users.noreply.translate."
-"fedoraproject.org>\n"
+"Last-Translator: ButterflyOfFire "
+"<butterflyoffire@users.noreply.translate.fedoraproject.org>\n"
 "Language-Team: Kabyle <https://translate.fedoraproject.org/projects/iputils/"
 "iputils/kab/>\n"
 "Language: kab\n"
@@ -1182,109 +1182,94 @@ msgstr ""
 msgid " (truncated)\n"
 msgstr ""
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " time=%ld.%03ld mts"
+msgid " time=%s ms"
+msgstr " akud=%s mts"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " akud=%ld mts"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " akud=%ld.%01ld mts"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " akud=%ld.%02ld mts"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr ""
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr ""
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr ""
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
 "wrong data byte #%d should be 0x%x but was 0x%x"
 msgstr ""
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s tidaddanin n ping ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld ikemmas yettwaṭfen, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld yettwaṭṭfen"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ""
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ""
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ""
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% d akemmus iruḥen"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", akud %llumts"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld mts"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr ""
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr ""
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld ikemmusen, %d%% iruḥen"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-22 13:38+0000\n"
 "Last-Translator: 김인수 <simmon@nplob.com>\n"
 "Language-Team: Korean <https://translate.fedoraproject.org/projects/iputils/"
@@ -1316,42 +1316,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (잘림)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " 시간=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " 시간=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " 시간=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " 시간=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " 시간=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (중복!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (잘못된 검사합!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (다른 주소!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1360,68 +1345,68 @@ msgstr ""
 "\n"
 "잘못된 자료 바이트 #%d는 0x%x이어야 하지만 0x%x입니다"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s ping 통계 ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld 패킷이 전송됨, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld 수신됨"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld 중복되었습니다"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld 손상됨"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld 오류"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% 패킷 손실"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", 시간 %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 "rtt 최소/평균/최대/표준편차 = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%s파이프 %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/지수가중평균 %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld 패킷, %d%% 손실"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-09-02 17:24+0000\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.fedoraproject.org/"
@@ -1324,42 +1324,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (truncado)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " tempo=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " tempo=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " tempo=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " tempo=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " tempo=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (SOMA DE VERIFICAÇÃO INVÁLIDA!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ENDEREÇO DIFERENTE!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1368,67 +1353,67 @@ msgstr ""
 "\n"
 "dados com byte incorreto #%d deveria ser 0x%x, mas era 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s estatísticas de ping ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld pacotes transmitidos, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld recebidos"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld duplicados"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld corrompidos"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld erros"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% perda de pacote"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", tempo %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt mín/méd/máx/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%spipe %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld pacotes, %d%% perda"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", mín/méd/ewma/máx = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/ro.po
+++ b/po/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <https://translate.fedoraproject.org/projects/"
@@ -1351,42 +1351,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (trunchiat)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " timp=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " timp=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " timp=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " timp=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " timp=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (SUMĂ DE CONTROL GREȘITĂ!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (ADRESĂ DIFERITĂ!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1395,67 +1380,67 @@ msgstr ""
 "\n"
 "octet de date greșit #%d ar trebui să fie 0x%x, dar a fost 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- statistici ping %s ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld pachete transmise, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld primite"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld duplicate"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld corupte"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld erori"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% pierderi de pachete"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", timp %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt min/med/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%sconductă %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld pachete, %d%% pierdere"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", min/med/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2024-10-19 18:38+0000\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
 "Language-Team: Turkish <https://translate.fedoraproject.org/projects/iputils/"
@@ -1321,42 +1321,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (kısaltıldı)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " zaman=%ld.%03ld ms"
+msgid " time=%s ms"
+msgstr " zaman=%s ms"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " zaman=%ld ms"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " zaman=%ld.%01ld ms"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " zaman=%ld.%02ld ms"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (YİNELENEN!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (YANLIŞ SAĞLAMA TOPLAMI!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (FARKLI ADRES!)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1365,69 +1350,69 @@ msgstr ""
 "\n"
 "yanlış veri baytı #%d, 0x%x olmalı ama 0x%x oldu"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s ping istatistikleri ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "%ld paket iletildi, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "%ld alındı"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld yinelenen"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld bozuk"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld hata"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %%%g paket kaybı"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", zaman %llums"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 "rtt en düşük/ortalama/en yüksek/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld."
 "%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%sboru %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d ms"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld paket, %%%d kayıp"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2025-01-01 19:31+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <https://translate.fedoraproject.org/projects/"
@@ -1345,42 +1345,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (обрізано)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " час=%ld.%03ld мс"
+msgid " time=%s ms"
+msgstr " час=%s мс"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " час=%ld мс"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " час=%ld.%01ld мс"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " час=%ld.%02ld мс"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (DUP!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (ПОМИЛКОВА КОНТРОЛЬНА СУМА!)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " (інша адреса)"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1389,67 +1374,67 @@ msgstr ""
 "\n"
 "помилковий байт даних %d — має бути 0x%x, але маємо 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- Статистика пінгування %s ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "Надіслано %ld пакетів, "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "отримано %ld"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld дублікатів"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld пошкоджено"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld помилок"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", втрачено %g%% пакетів"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", час %llu мс"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr "rtt мін/сер/макс/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld мс"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%sканал %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d мс"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld з %ld пакетів, втрачено %d%%"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", мін/сер/ewma/макс = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld мс"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: iputils\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-15 17:30+0100\n"
+"POT-Creation-Date: 2025-01-03 22:19+0100\n"
 "PO-Revision-Date: 2023-12-20 15:03+0000\n"
 "Last-Translator: yangyangdaji <1504305527@qq.com>\n"
 "Language-Team: Chinese (Simplified) <https://translate.fedoraproject.org/"
@@ -1301,42 +1301,27 @@ msgstr " ttl=%d"
 msgid " (truncated)\n"
 msgstr " (已截断)\n"
 
-#: ping/ping_common.c:826 ping/ping_common.c:836
+#: ping/ping_common.c:849
 #, c-format
-msgid " time=%ld.%03ld ms"
-msgstr " 时间=%ld.%03ld 毫秒"
+msgid " time=%s ms"
+msgstr " 时间=%s 毫秒"
 
-#: ping/ping_common.c:828
-#, c-format
-msgid " time=%ld ms"
-msgstr " 时间=%ld 毫秒"
-
-#: ping/ping_common.c:830
-#, c-format
-msgid " time=%ld.%01ld ms"
-msgstr " 时间=%ld.%01ld 毫秒"
-
-#: ping/ping_common.c:833
-#, c-format
-msgid " time=%ld.%02ld ms"
-msgstr " 时间=%ld.%02ld 毫秒"
-
-#: ping/ping_common.c:841
+#: ping/ping_common.c:854
 #, c-format
 msgid " (DUP!)"
 msgstr " (重复!)"
 
-#: ping/ping_common.c:843
+#: ping/ping_common.c:856
 #, c-format
 msgid " (BAD CHECKSUM!)"
 msgstr " (CHECKSUM 错误)"
 
-#: ping/ping_common.c:845
+#: ping/ping_common.c:858
 #, c-format
 msgid " (DIFFERENT ADDRESS!)"
 msgstr " （地址不同！）"
 
-#: ping/ping_common.c:852
+#: ping/ping_common.c:865
 #, c-format
 msgid ""
 "\n"
@@ -1345,68 +1330,68 @@ msgstr ""
 "\n"
 "错误的数据字节 #%d 预期为 0x%x 但实际接收到 0x%x"
 
-#: ping/ping_common.c:895
+#: ping/ping_common.c:908
 #, c-format
 msgid "--- %s ping statistics ---\n"
 msgstr "--- %s ping 统计 ---\n"
 
-#: ping/ping_common.c:896
+#: ping/ping_common.c:909
 #, c-format
 msgid "%ld packets transmitted, "
 msgstr "已发送 %ld 个包， "
 
-#: ping/ping_common.c:897
+#: ping/ping_common.c:910
 #, c-format
 msgid "%ld received"
 msgstr "已接收 %ld 个包"
 
-#: ping/ping_common.c:899
+#: ping/ping_common.c:912
 #, c-format
 msgid ", +%ld duplicates"
 msgstr ", +%ld 重复"
 
-#: ping/ping_common.c:901
+#: ping/ping_common.c:914
 #, c-format
 msgid ", +%ld corrupted"
 msgstr ", +%ld 损坏"
 
-#: ping/ping_common.c:903
+#: ping/ping_common.c:916
 #, c-format
 msgid ", +%ld errors"
 msgstr ", +%ld 错误"
 
-#: ping/ping_common.c:909
+#: ping/ping_common.c:922
 #, c-format
 msgid ", %g%% packet loss"
 msgstr ", %g%% 包丢失"
 
-#: ping/ping_common.c:911
+#: ping/ping_common.c:924
 #, c-format
 msgid ", time %llums"
 msgstr ", 耗时 %llu 毫秒"
 
-#: ping/ping_common.c:931
+#: ping/ping_common.c:944
 #, c-format
 msgid "rtt min/avg/max/mdev = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 msgstr ""
 "rtt 最小/平均/移动平均/最大 = %ld.%03ld/%lu.%03ld/%ld.%03ld/%ld.%03ld ms"
 
-#: ping/ping_common.c:939
+#: ping/ping_common.c:952
 #, c-format
 msgid "%spipe %d"
 msgstr "%s 管道 %d"
 
-#: ping/ping_common.c:946
+#: ping/ping_common.c:959
 #, c-format
 msgid "%sipg/ewma %d.%03d/%d.%03d ms"
 msgstr "%sipg/ewma %d.%03d/%d.%03d 毫秒"
 
-#: ping/ping_common.c:964
+#: ping/ping_common.c:977
 #, c-format
 msgid "%ld/%ld packets, %d%% loss"
 msgstr "%ld/%ld 个包，%d%% 丢失"
 
-#: ping/ping_common.c:969
+#: ping/ping_common.c:982
 #, c-format
 msgid ", min/avg/ewma/max = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld ms"
 msgstr ", 最小/平均/移动平均/最大 = %ld.%03ld/%lu.%03ld/%d.%03d/%ld.%03ld 毫秒"


### PR DESCRIPTION
Tiny i18n related improvement. Phrase `"time=... ms"` should be translated only once. To achieve it avoid float printf formatting in `_()` gettext.
