### PR TITLE
ping: Fix signed 64-bit integer overflow in RTT calculation

### DIFF
--- a/iputils_common.h
+++ b/iputils_common.h
@@ -10,6 +10,9 @@
 	  !!__builtin_types_compatible_p(__typeof__(arr), \
 					 __typeof__(&arr[0]))])) * 0)
 
+/* 1000001 = 1000000 tv_sec + 1 tv_usec */
+#define TV_SEC_MAX_VAL (LONG_MAX/1000001)
+
 #ifdef __GNUC__
 # define iputils_attribute_format(t, n, m) __attribute__((__format__ (t, n, m)))
 #else


### PR DESCRIPTION
Crafted ICMP Echo Reply packet can cause signed integer overflow in

1) triptime calculation:
triptime = tv->tv_sec * 1000000 + tv->tv_usec;

2) tsum2 increment which uses triptime
rts->tsum2 += (double)((long long)triptime * (long long)triptime);

3) final tmvar:
tmvar = (rts->tsum2 / total) - (tmavg * tmavg)
---

    $ export CFLAGS="-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer"
    $ export LDFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
    $ meson setup .. -Db_sanitize=address,undefined
    $ ninja
    $ ./ping/ping -c2 127.0.0.1

    PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
    64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.061 ms
    ../ping/ping_common.c:757:25: runtime error: signed integer overflow: -2513732689199106 * 1000000 cannot be represented in type 'long int'
    ../ping/ping_common.c:757:12: runtime error: signed integer overflow: -4975495174606980224 + -6510615555425289427 cannot be represented in type 'long int'
    ../ping/ping_common.c:769:47: runtime error: signed integer overflow: 6960633343677281965 * 6960633343677281965 cannot be represented in type 'long int'
    24 bytes from 127.0.0.1: icmp_seq=1 ttl=64 (truncated)
    ./ping/ping: Warning: time of day goes back (-7256972569576721377us), taking countermeasures
    ./ping/ping: Warning: time of day goes back (-7256972569576721232us), taking countermeasures
    24 bytes from 127.0.0.1: icmp_seq=1 ttl=64 (truncated)
    ../ping/ping_common.c:265:16: runtime error: signed integer overflow: 6960633343677281965 * 2 cannot be represented in type 'long int'
    64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.565 ms

    --- 127.0.0.1 ping statistics ---
    2 packets transmitted, 2 received, +2 duplicates, 0% packet loss, time 1002ms
    ../ping/ping_common.c:940:42: runtime error: signed integer overflow: 1740158335919320832 * 1740158335919320832 cannot be represented in type 'long int'
    rtt min/avg/max/mdev = 0.000/1740158335919320.832/6960633343677281.965/-1623514645242292.-224 ms

To fix the overflow check allowed ranges of struct timeval members:
* tv_sec <-LONG_MAX/1000000, LONG_MAX/1000000>
* tv_usec <0, 999999>

Fix includes 2 new error messages (needs translation).

After fix:

    $ ./ping/ping -c2 127.0.0.1
    PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
    64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.059 ms
    ./ping/ping: Warning: overflow tv_usec -6510615555425457380 us
    ./ping/ping: Warning: invalid tv_sec -1789369274859522 s
    24 bytes from 127.0.0.1: icmp_seq=1 ttl=64 (truncated)
    ./ping/ping: Warning: overflow tv_usec -6510615555425413387 us
    ./ping/ping: Warning: invalid tv_sec -2006106209517570 s
    24 bytes from 127.0.0.1: icmp_seq=1 ttl=64 (truncated)
    64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.118 ms

    --- 127.0.0.1 ping statistics ---
    2 packets transmitted, 2 received, +2 duplicates, 0% packet loss, time 1002ms
    rtt min/avg/max/mdev = 0.000/0.044/0.118/0.048 ms


Fixes: https://github.com/iputils/iputils/issues/584
Fixes: CVE-2025-472
Link: https://github.com/Zephkek/ping-rtt-overflow/
Co-developed-by: Cyril Hrubis <chrubis@suse.cz>
Reported-by: Mohamed Maatallah <hotelsmaatallahrecemail@gmail.com>
