### PR TITLE
ping: Fix ipv4 ttl value when using SOCK_DGRAM on big endian systems

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1642,7 +1642,7 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 	int csfailed;
 	struct cmsghdr *cmsgh;
 	int reply_ttl;
-	uint8_t *opts, *tmp_ttl;
+	uint8_t *opts;
 	int olen;
 	int wrong_source = 0;
 
@@ -1670,8 +1670,7 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 			if (cmsgh->cmsg_type == IP_TTL) {
 				if (cmsgh->cmsg_len < sizeof(int))
 					continue;
-				tmp_ttl = (uint8_t *)CMSG_DATA(cmsgh);
-				reply_ttl = (int)*tmp_ttl;
+				memcpy(&reply_ttl, CMSG_DATA(cmsgh), sizeof(reply_ttl));
 			} else if (cmsgh->cmsg_type == IP_RETOPTS) {
 				opts = (uint8_t *)CMSG_DATA(cmsgh);
 				olen = cmsgh->cmsg_len;


### PR DESCRIPTION
When testing on a big endian (IBM s390) system I recently noticed that when pinging ipv4 addresses and using the SOCK_DGRAM interface the value returned for the ttl is always 0, for example:

`s390init03:~ # ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=0 time=0.054 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=0 time=0.056 ms
64 bytes from 127.0.0.1: icmp_seq=3 ttl=0 time=0.114 ms
^C
--- 127.0.0.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2097ms
rtt min/avg/max/mdev = 0.054/0.074/0.114/0.027 ms`

I have traced it back to a commit fixing GCC warnings, which cast the value returned by CMSG_DATA to a uint8_t, hence losing the actual useful data on big endian systems.