### PR TITLE
ping: Fix regression in -c1

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -335,7 +335,7 @@ main(int argc, char **argv)
 	static struct ping_rts rts = {
 		.interval = 1000,
 		.preload = 1,
-		.lingertime = MAXWAIT * 1000,
+		.lingertime = MAXWAIT * 1000000,
 		.confirm_flag = MSG_CONFIRM,
 		.tmin = LONG_MAX,
 		.pipesize = -1,

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -389,7 +389,7 @@ resend:
 		if (nores_interval > 500)
 			nores_interval = 500;
 		oom_count++;
-		if ((uint32_t)(oom_count * nores_interval) < rts->lingertime)
+		if ((uint32_t)(oom_count * nores_interval) < rts->lingertime/1000)
 			return nores_interval;
 		i = 0;
 		/* Fall to hard error. It is to avoid complete deadlock


### PR DESCRIPTION
We changed the rts->lingertime to be stored directly in us instead of ms in order to simplify the overflow checks, however we missed two places where the value was not properly converted.

The initialization of the lingertime has to be converted to us as well since the MAXWAIT is in seconds it has to be multiplied by 1000000 now.

The check againts the nores_interval has to be updated too since the nores_interval is initialized from rts->interval that is stored in ms and the oom_count is a counter, hence the product of the multiplication is still in ms and the rts->lingertime has to be divided by 1000 in this case to be converted back to ms.

Fixes: f7d1989 ("ping: Fix integer overflow in large -W value")
Fixes: iputils#596
Reported-by: Alberto Salvia Novella <es20490446e.wordpress.com>
Co-developed-by: Petr Vorel <pvorel@suse.cz>
Signed-off-by: Cyril Hrubis <chrubis@suse.cz>