### PR TITLE
Unaligned memory access in call to gettimeofday, function build_echo (SIGBUS crash)

### DIFF
--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -601,8 +601,11 @@ int build_echo(struct ping_rts *rts, uint8_t *_icmph,
 	icmph->icmp6_seq = htons(rts->ntransmitted + 1);
 	icmph->icmp6_id = rts->ident;
 
-	if (rts->timing)
-		gettimeofday((struct timeval *)&_icmph[8], NULL);
+        if (rts->timing) {
+	        struct timeval tv;
+	        gettimeofday(&tv, NULL);
+	        memcpy(&_icmph[8], &tv, sizeof(tv));
+        }
 
 	cc = rts->datalen + 8;			/* skips ICMP portion */
 


### PR DESCRIPTION
There's a memory alignment issue in ping6_common.c, build_echo() which causes ping to IPv6 addresses to crash with SIGBUS error on SPARC architecture

See #598 for details


Resolves #598 