### PR TITLE
meson.build: strict check for error function

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -143,7 +143,7 @@ endif
 foreach h : [
 	'error.h',
 ]
-	if cc.has_header(h)
+	if cc.has_header(h) and cc.has_function('error')
 		conf.set('HAVE_' + h.to_upper().underscorify(), 1,
 			description : 'Define if ' + h + ' can be included.')
 	endif


### PR DESCRIPTION
Along with checking for presense of error.h we should also check if we can use the error function and it's getting properly linked.

Dowstream-bug: https://bugs.gentoo.org/947680

Hit his bug while building on Gentoo musl with sys-libs/error-standalone package. The sys-libs/error-standalone package provides a error.h file for users' comfort when compiling third-party software. But it's not if not linked properly we get build error such as

```
libtool: link: ( cd "library/.libs" && rm -f "libproc2.la" && ln -s "../libproc2.la" "libproc2.la" )
/bin/sh ./libtool  --tag=CC   --mode=link powerpc64-unknown-linux-musl-gcc -std=gnu99 -Ilibrary/include -Os -pipe -mcpu=970 -mtune=970 -maltivec -mabi=altivec  -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -o src/ps/pscommand src/ps/display.o src/ps/global.o src/ps/help.o src/ps/output.o src/ps/parser.o src/ps/select.o src/ps/signames.o src/ps/sortformat.o src/ps/stacktrace.o local/fileutils.o local/signals.o ./library/libproc2.la  
libtool: link: powerpc64-unknown-linux-musl-gcc -std=gnu99 -Ilibrary/include -Os -pipe -mcpu=970 -mtune=970 -maltivec -mabi=altivec -Wl,-O1 -Wl,--as-needed -Wl,-z -Wl,pack-relative-relocs -o src/ps/.libs/pscommand src/ps/display.o src/ps/global.o src/ps/help.o src/ps/output.o src/ps/parser.o src/ps/select.o src/ps/signames.o src/ps/sortformat.o src/ps/stacktrace.o local/fileutils.o local/signals.o  ./library/.libs/libproc2.so -lelogind
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/display.o: in function `signal_handler':
display.c:(.text+0xe4): undefined reference to `error_at_line'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/display.o: in function `xmalloc':
display.c:(.text+0x3e0): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/display.o: in function `xcalloc':
display.c:(.text+0x448): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/global.o: in function `reset_global':
global.c:(.text+0x4d4): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/global.o: in function `catastrophic_failure':
global.c:(.text+0xbec): undefined reference to `error_at_line'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/output.o: in function `boot_time':
output.c:(.text+0x2128): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/output.o: in function `pr_pmem':
output.c:(.text+0x84ec): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/parser.o: in function `xmalloc':
parser.c:(.text+0x79c): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/parser.o: in function `xcalloc.constprop.0':
parser.c:(.text+0x890): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: src/ps/sortformat.o: in function `xmalloc':
sortformat.c:(.text+0x44): undefined reference to `error'
/usr/lib/gcc/powerpc64-unknown-linux-musl/14/../../../../powerpc64-unknown-linux-musl/bin/ld: local/fileutils.o:fileutils.c:(.text+0x110): more undefined references to `error' follow
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:1592: src/ps/pscommand] Error 1
make[2]: Leaving directory '/var/tmp/portage/sys-process/procps-4.0.4-r2/work/procps-ng-4.0.4-.ppc64'
make[1]: *** [Makefile:2254: all-recursive] Error 1
make[1]: Leaving directory '/var/tmp/portage/sys-process/procps-4.0.4-r2/work/procps-ng-4.0.4-.ppc64'
make: *** [Makefile:1185: all] Error 2
 * ERROR: sys-process/procps-4.0.4-r2::gentoo failed (compile phase):
```

So a stricter check for error should help. Along with checking for error.h we should also check if error function can be used.

Steps to reproduce:
1. on Gentoo install the `sys-libs/error-standalone` package
2. Build
3. Observe failure.
