### PR TITLE
[WIP] ping: Fix regression from JSON support, improve JSON

### DIFF
--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -834,6 +834,17 @@ restamp:
 		uint8_t *cp, *dp;
 
 		print_timestamp(rts);
+
+		if (rts->opt_json) {
+			// TODO: improve key name
+			construct_json(rts, PING_JSON_INT, "data_bytes", rts->datalen);
+			/*
+			 * FIXME: Add this require either add ping_func_set_st *fset or move into ping_print_packet().
+			if (fset->ping_data_bytes)
+				construct_json(rts, PING_JSON_INT, "data_bytes_full", fset->ping_data_bytes(rts));
+			*/
+		}
+
 		ping_print_int(rts, _("%d bytes "), "bytes", cc);
 		// TODO: split host IP address and name into separate attributes in JSON?
 		ping_print_str(rts, _("from %s:"), "host", from);


### PR DESCRIPTION
First draft of fix for https://github.com/iputils/iputils/issues/605 (broken non-JSON output for IPv4).

The fix itself is ready (first commit). If we aim to get a quick fix it could be merged separately.

```diff
-PING ::1 (0.0.0.0) 56(84) bytes of data. # wrong
+PING ::1 (::1) 56 data bytes # fixed
```

Then there is an attempt to add to JSON data length values (numbers `56` and `84`) from ping header in the second commit:
```
$ ping 127.0.0.1 # IPv4
PING 127.0.0.1 (127.0.0.1) 56 (84) data bytes
...
$ ping ::1 # IPv6
PING ::1 (::1) 56 data bytes
...
```
RFC: The last commit is touching non-JSON ping output - changing IPv4 `"%d(%d) bytes of data."` string to `"%d (%d) data bytes"` (to unify with  `"%d data bytes"` IPv6 string. I'm not sure myself if it's a good idea. It's dangerous to touch output because there might be some broken scripts. And it will take years when people start using JSON output (some newer if aim for busybox ping implementation compatibility). And if used, maybe put a description for second number?

TODO: there is missing source and target JSON (the part which has been fixed in the first commit).