### PR TITLE
Improved testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2021-2024 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021-2025 Petr Vorel <pvorel@suse.cz>
 
 name: "CI: docker based builds"
 on: [push, pull_request]
@@ -127,7 +127,7 @@ jobs:
         INSTALL="${INSTALL#quay.io/centos/}"
         INSTALL="${INSTALL%%:*}"
         INSTALL="${INSTALL%%/*}"
-        ./ci/$INSTALL.sh
+        WITH_TEST_DEPS=1 ./ci/$INSTALL.sh
         if [ "$VARIANT" ]; then ./ci/$INSTALL.$VARIANT.sh; fi
 
     - name: Check dependencies

--- a/build-aux/meson-build-dist-man.sh
+++ b/build-aux/meson-build-dist-man.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eu
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) Iputils Project, 2024
+# Copyright (c) Iputils Project, 2024-2025
 #
 # This script should be invoked by meson itself on 'meson dist'
 # (invoked by tools/create-tarballs.sh).
@@ -16,7 +16,7 @@ fi
 cd "$MESON_DIST_ROOT"
 DIR=$(mktemp -d)
 
-meson setup "$DIR" -DBUILD_MANS=true -DBUILD_HTML_MANS=true
+meson setup "$DIR" -DBUILD_MANS=true -DBUILD_HTML_MANS=true -DSKIP_TESTS=true
 meson compile -C "$DIR"
 cp -v "$DIR"/doc/* doc/
 rm -rf "$DIR"

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2019-2024 Petr Vorel <petr.vorel@gmail.com>
+# Copyright (c) 2019-2025 Petr Vorel <petr.vorel@gmail.com>
 set -ex
 
 apk update
+
+if [ "$WITH_TEST_DEPS" ]; then
+	TEST_DEPS="
+	perl-socket-getaddrinfo
+	perl-test-command
+"
+fi
 
 # NOTE: libidn2-dev is not in 3.10, only in edge
 apk add \
@@ -20,4 +27,5 @@ apk add \
 	libxslt \
 	meson \
 	musl-dev \
-	pkgconfig
+	pkgconfig \
+	$TEST_DEPS

--- a/ci/debian.sh
+++ b/ci/debian.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2019-2024 Petr Vorel <petr.vorel@gmail.com>
+# Copyright (c) 2019-2025 Petr Vorel <petr.vorel@gmail.com>
 set -ex
 
 if [ "$DISTRO_VERSION" = "xenial" ]; then
@@ -15,6 +15,13 @@ export DEBIAN_FRONTEND="noninteractive"
 
 apt update
 
+if [ "$WITH_TEST_DEPS" ]; then
+	TEST_DEPS="
+	libsocket-getaddrinfo-perl
+	libtest-command-perl
+"
+fi
+
 apt install -y --no-install-recommends \
 	clang \
 	docbook-xsl-ns \
@@ -28,4 +35,5 @@ apt install -y --no-install-recommends \
 	libidn2-0-dev \
 	meson \
 	pkg-config \
-	xsltproc
+	xsltproc \
+	$TEST_DEPS

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2019-2024 Petr Vorel <petr.vorel@gmail.com>
+# Copyright (c) 2019-2025 Petr Vorel <petr.vorel@gmail.com>
 set -ex
 
-yum -y install \
+yum='yum -y install'
+
+$yum \
 	clang \
 	file \
 	findutils \
@@ -19,7 +21,7 @@ yum -y install \
 if [ "$(basename $0)" = "centos.sh" ] || [ "$(basename $0)" = "rockylinux.sh" ]; then
 	# CentOS Linux 7: libidn2-devel, meson, ninja-build are provided by EPEL
 	# CentOS/RHEL/Rocky 8: docbook5-style-xsl is provided by EPEL
-	yum -y install epel-release
+	$yum epel-release
 
 	# Enable CRB (formerly PowerTools) on CentOS/RHEL/Rocky >= 8 via EPEL
 	# CentOS/RHEL/Rocky >= 8: meson and ninja-build are provided by CRB
@@ -31,4 +33,11 @@ if [ "$(basename $0)" = "centos.sh" ] || [ "$(basename $0)" = "rockylinux.sh" ];
 	fi
 fi
 
-yum -y install docbook5-style-xsl libidn2-devel meson ninja-build
+$yum docbook5-style-xsl libidn2-devel meson ninja-build
+
+if [ "$WITH_TEST_DEPS" ]; then
+	if ! $yum perl-Test-Command perl-Socket-GetAddrInfo; then
+		$yum perl-CPAN
+		perl -MCPAN -e 'install Socket::GetAddrInfo; install Test::Command; install Test::More'
+	fi
+fi

--- a/ci/opensuse.sh
+++ b/ci/opensuse.sh
@@ -1,9 +1,21 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2018-2024 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2018-2025 Petr Vorel <pvorel@suse.cz>
 set -ex
 
-zypper --non-interactive install --no-recommends \
+zypper='zypper --non-interactive install --no-recommends'
+
+if [ "$WITH_TEST_DEPS" ]; then
+	TEST_DEPS="
+	perl-Test-Command
+"
+	if ! $zypper perl-Socket-GetAddrInfo; then
+		$zypper make perl
+		PERL_MM_USE_DEFAULT=1 cpan -T Socket::GetAddrInfo
+	fi
+fi
+
+$zypper \
 	clang \
 	docbook_5 \
 	docbook5-xsl-stylesheets \
@@ -19,4 +31,5 @@ zypper --non-interactive install --no-recommends \
 	libxslt-tools \
 	meson \
 	ninja \
-	pkg-config
+	pkg-config \
+	$TEST_DEPS

--- a/iputils_common.c
+++ b/iputils_common.c
@@ -20,7 +20,7 @@ void error(int status, int errnum, const char *format, ...)
 {
 	va_list ap;
 
-	fprintf(stderr, "%s: ", program_invocation_short_name);
+	fprintf(stderr, "%s: ", program_invocation_name);
 	va_start(ap, format);
 	vfprintf(stderr, format, ap);
 	va_end(ap);

--- a/test/arping/arping-01-basic.t
+++ b/test/arping/arping-01-basic.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+use Test::Command tests => 2;
+use Test::More;
+
+my $lib = File::Basename::dirname(Cwd::abs_path($0)) . '/../lib.pl';
+require "$lib";
+
+my $arping = get_cmd($ARGV[0] // 'arping');
+
+# -V
+{
+    my $cmd = Test::Command->new(cmd => "$arping -V");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/^arping from iputils /, 'Print version');
+		$cmd->stdout_like(qr/libcap: (yes|no), IDN: (yes|no), NLS: (yes|no), error.h: (yes|no), getrandom\(\): (yes|no), __fpending\(\): (yes|no)$/, 'Print config');
+	}
+}

--- a/test/arping/meson.build
+++ b/test/arping/meson.build
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2021 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021-2025 Petr Vorel <pvorel@suse.cz>
 
-cmd = arping
-cmd_name = 'arping '
-args = ['-V']
+message('Build directory is: ' + meson.current_build_dir())
 
-name = cmd_name + ' '.join(args)
-test(name, cmd, args : args)
+foreach t : ['arping-01-basic.t']
+  test(t, find_program(t), args: arping)
+endforeach

--- a/test/clockdiff/clockdiff-01-basic.t
+++ b/test/clockdiff/clockdiff-01-basic.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+use Test::Command tests => 2;
+use Test::More;
+
+my $lib = File::Basename::dirname(Cwd::abs_path($0)) . '/../lib.pl';
+require "$lib";
+
+my $clockdiff = get_cmd($ARGV[0] // 'clockdiff');
+
+# -V
+{
+    my $cmd = Test::Command->new(cmd => "$clockdiff -V");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/^clockdiff from iputils /, 'Print version');
+		$cmd->stdout_like(qr/libcap: (yes|no), IDN: (yes|no), NLS: (yes|no), error.h: (yes|no), getrandom\(\): (yes|no), __fpending\(\): (yes|no)$/, 'Print config');
+	}
+}

--- a/test/clockdiff/meson.build
+++ b/test/clockdiff/meson.build
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2021 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021-2025 Petr Vorel <pvorel@suse.cz>
 
-cmd = clockdiff
-cmd_name = 'clockdiff '
-args = ['-V']
+message('Build directory is: ' + meson.current_build_dir())
 
-name = cmd_name + ' '.join(args)
-test(name, cmd, args : args)
+foreach t : ['clockdiff-01-basic.t']
+  test(t, find_program(t), args: clockdiff)
+endforeach

--- a/test/lib.pl
+++ b/test/lib.pl
@@ -1,0 +1,31 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+our @EXPORT_OK = qw(get_cmd);
+
+sub init
+{
+	exit 77 if (defined($ENV{VARIANT}) && $ENV{VARIANT} eq 'cross-compile');
+
+	$ENV{LC_ALL} = 'C';
+	$ENV{LANG} = 'C';
+
+	diag("Running as UID: $>");
+}
+
+sub get_cmd
+{
+	my $cmd = shift;
+
+	init();
+
+	diag("PATH = $ENV{PATH}");
+	diag("passed cmd: $cmd");
+	printf("# actually used cmd: ");
+	system("/bin/sh", "-c", "command -v $cmd");
+
+	return "$cmd";
+}
+
+1;

--- a/test/ping/meson.build
+++ b/test/ping/meson.build
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2021 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021-2025 Petr Vorel <pvorel@suse.cz>
 
+message('Build directory is: ' + meson.current_build_dir())
+
+foreach t : ['ping-01-basics.t', 'ping-02-errors.t' ]
+  test(t, find_program(t), args: ping)
+endforeach
+
+# FIXME: convert to perl
 # GitHub CI does not have working IPv6
 # https://github.com/actions/virtual-environments/issues/668
 ipv6_dst = []

--- a/test/ping/ping-01-basics.t
+++ b/test/ping/ping-01-basics.t
@@ -1,0 +1,161 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+use Socket qw(AF_INET AF_INET6 AF_UNSPEC AI_CANONNAME IPPROTO_UDP SOCK_STREAM);
+use Socket::GetAddrInfo qw(getaddrinfo);
+use Test::Command tests => 11;
+use Test::More;
+
+my $lib = File::Basename::dirname(Cwd::abs_path($0)) . '/../lib.pl';
+require "$lib";
+
+my $ping = get_cmd($ARGV[0] // 'ping');
+
+# Mock getaddrinfo() related code in ping/ping.c main() followed by logic in
+# ping4_run() and ping6_run().
+sub get_target
+{
+	my $target = shift;
+	my $target_ai_family = shift // AF_UNSPEC;
+
+	# ping/ping.c main(): getaddrinfo() to detect IPv4 vs. IPv6
+	my $hints = {
+		flags     => AI_CANONNAME,
+		family    => $target_ai_family,
+		socktype  => SOCK_STREAM,
+	};
+
+	die "invalid family: '$target_ai_family'" unless ($target_ai_family == AF_INET
+		|| $target_ai_family == AF_INET6 || $target_ai_family == AF_UNSPEC);
+
+	my ($err, @res) = getaddrinfo($target, undef, $hints);
+	die "getaddrinfo error: $err\n" if $err;
+
+	foreach my $ai (@res) {
+		next if $target_ai_family != AF_UNSPEC && $target_ai_family != $ai->{family};
+
+		# ping/ping.c ping6_run(): AF_INET6 does not perform getaddrinfo()
+		return $target if ($ai->{family} == AF_INET6);
+
+		# ping/ping6_common.c ping4_run(): AF_INET has extra getaddrinfo() to
+		# get canonname.
+		$hints = {
+			ai_family   => AF_INET,
+			ai_protocol => IPPROTO_UDP,
+
+			# getaddrinfo_flags: USE_IDN=true adds AI_IDN | AI_CANONIDN, but
+			# they aren't supported by musl (via Alpine):
+			# Your vendor has not defined Socket macro AI_IDN and AI_CANONIDN, used at
+			# builddir/meson-private/dist-unpack/iputils-20250605/test/ping/ping-01-basics.t line 43
+			ai_flags    => AI_CANONNAME | AI_CANONIDN,
+		};
+		my ($err, @res) = getaddrinfo($target, undef, $hints);
+		die "getaddrinfo error: $err\n" if $err;
+
+		return defined($ai->{canonname}) ? $ai->{canonname} : $target;
+	}
+}
+
+# -V
+{
+    my $cmd = Test::Command->new(cmd => "$ping -V");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/^ping from iputils /, 'Print version');
+		$cmd->stdout_like(qr/libcap: (yes|no), IDN: (yes|no), NLS: (yes|no), error.h: (yes|no), getrandom\(\): (yes|no), __fpending\(\): (yes|no)$/, 'Print config');
+	}
+}
+
+# 127.0.0.1
+{
+    my $cmd = Test::Command->new(cmd => "$ping -c1 127.0.0.1");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/64 bytes from 127\.0\.0\.1/, 'Ping received from 127.0.0.1');
+		$cmd->stdout_like(qr/0% packet loss/, 'No packet loss');
+		$cmd->stdout_like(qr/time=\d+\.\d+ ms/, 'Ping time present');
+		$cmd->stdout_like(qr~rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$~,
+			'RTT time present');
+		$cmd->stdout_like(qr{^PING 127\.0\.0\.1 \(127\.0\.0\.1\) 56\(84\) bytes of data\.
+64 bytes from 127\.0\.0\.1: icmp_seq=1 ttl=\d+ time=\d\.\d{3} ms
+
+--- 127.0.0.1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time \d+ms
+rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$},
+'Entire ping output matched exactly');
+	}
+}
+
+# ::1
+SKIP: {
+    if ($ENV{SKIP_IPV6}) {
+        skip 'IPv6 tests', 2;
+    }
+    my $cmd = Test::Command->new(cmd => "$ping -c1 ::1");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/64 bytes from ::1/, 'Ping received from ::1');
+		$cmd->stdout_like(qr/0% packet loss/, 'No packet loss');
+		$cmd->stdout_like(qr/time=\d+\.\d+ ms/, 'Ping time present');
+		$cmd->stdout_like(qr~rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$~,
+			'RTT time present');
+		$cmd->stdout_like(qr{^PING ::1 \(::1\) 56 data bytes
+64 bytes from ::1: icmp_seq=1 ttl=\d+ time=\d\.\d{3} ms
+
+--- ::1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time \d+ms
+rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$},
+'Entire ping output matched exactly');
+	}
+}
+
+my $localhost = "localhost";
+my $localhost_target_ipv4 = get_target($localhost, AF_INET);
+my $localhost_target_ipv6 = get_target($localhost, AF_INET6);
+diag("localhost_cannon_ipv4: '$localhost_target_ipv4'");
+diag("localhost_cannon_ipv6: '$localhost_target_ipv6'");
+die "Undefined cannonical name for $localhost on IPv4" unless defined $localhost_target_ipv4;
+die "Undefined cannonical name for $localhost on IPv6" unless defined $localhost_target_ipv6;
+
+# localhost
+{
+    my $cmd = Test::Command->new(cmd => "$ping -c1 $localhost");
+    $cmd->exit_is_num(0);
+}
+
+# -4 localhost
+{
+    my $cmd = Test::Command->new(cmd => "$ping -c1 -4 $localhost");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/64 bytes from $localhost_target_ipv4 \(127\.0\.0\.1\)/, "Ping received from $localhost (IPv4)");
+		$cmd->stdout_like(qr/0% packet loss/, 'No packet loss');
+		$cmd->stdout_like(qr/time=\d+\.\d+ ms/, 'Ping time present');
+		$cmd->stdout_like(qr~rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$~,
+			'RTT time present');
+		$cmd->stdout_like(qr{^PING $localhost_target_ipv4 \(127\.0\.0\.1\) 56\(84\) bytes of data\.
+64 bytes from $localhost_target_ipv4 \(127\.0\.0\.1\): icmp_seq=1 ttl=\d+ time=\d\.\d{3} ms
+
+--- $localhost_target_ipv4 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time \d+ms
+rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$},
+'Entire ping output matched exactly');
+	}
+}
+
+# -6 localhost
+SKIP: {
+    if ($ENV{SKIP_IPV6}) {
+        skip 'IPv6 tests', 2;
+    }
+    my $cmd = Test::Command->new(cmd => "$ping -c1 -6 $localhost");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/64 bytes from $localhost_target_ipv6 \(::1\)/, "Ping received from $localhost (IPv6)");
+		$cmd->stdout_like(qr/0% packet loss/, 'No packet loss');
+		$cmd->stdout_like(qr/time=\d+\.\d+ ms/, 'Ping time present');
+		$cmd->stdout_like(qr~rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$~,
+			'RTT time present');
+	}
+}

--- a/test/ping/ping-02-errors.t
+++ b/test/ping/ping-02-errors.t
@@ -1,0 +1,73 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+use Test::Command tests => 6;
+use Test::More;
+
+my $lib = File::Basename::dirname(Cwd::abs_path($0)) . '/../lib.pl';
+require "$lib";
+
+my $ping = get_cmd($ARGV[0] // 'ping');
+
+# no arg
+{
+	my $cmd = Test::Command->new(cmd => "$ping");
+	$cmd->exit_is_num(2);
+	subtest 'output' => sub {
+		$cmd->stderr_is_eq("$ping: usage error: Destination address required\n");
+	}
+}
+
+# -c1 -i0.001 127.0.0.1
+{
+	my $cmd = Test::Command->new(cmd => "$ping -c1 -i0.001 127.0.0.1");
+	$cmd->exit_is_num($> == 0 ? 0 : 2);
+	subtest 'output' => sub {
+		if ($> == 0) {
+			$cmd->stdout_like(qr/^PING 127\.0\.0\.1.*bytes of data\.$/m, 'Ping header');
+			$cmd->stdout_like(qr/64 bytes from 127\.0\.0\.1: icmp_seq=1 ttl=\d+ time=\d+\.\d+ ms/m, 'Ping reply line');
+			$cmd->stdout_like(qr/1 packets transmitted, 1 received, 0% packet loss/, 'Ping success summary');
+			$cmd->stdout_like(qr{^PING 127\.0\.0\.1 \(127\.0\.0\.1\) 56\(84\) bytes of data\.
+64 bytes from 127\.0\.0\.1: icmp_seq=1 ttl=\d+ time=\d\.\d{3} ms
+
+--- 127.0.0.1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time \d+ms
+rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$},
+'Entire ping output matched exactly');
+		} else {
+			$cmd->stderr_like(qr/cannot flood/i);
+			$cmd->stdout_like(qr/PING 127\.0\.0\.1/);
+			$cmd->stderr_like(qr/use -i 0\.002/);
+			$cmd->stderr_like(qr/.*ping: cannot flood, minimal interval for user must be >= 2 ms, use -i 0\.002 \(or higher\)/);
+		}
+	}
+}
+
+# -c1 -i0.001 ::1
+SKIP: {
+    if ($ENV{SKIP_IPV6}) {
+        skip 'IPv6 tests', 2;
+    }
+	my $cmd = Test::Command->new(cmd => "$ping -c1 -i0.001 ::1", env => { LC_ALL => 'C', LANG   => 'C' });
+	$cmd->exit_is_num($> == 0 ? 0 : 2);
+	subtest 'output' => sub {
+		if ($> == 0) {
+			$cmd->stdout_like(qr/^PING ::1 \(::1\) 56 data bytes$/m, 'Ping header');
+			$cmd->stdout_like(qr/64 bytes from ::1: icmp_seq=1 ttl=\d+ time=\d+\.\d+ ms/m, 'Ping reply line');
+			$cmd->stdout_like(qr/1 packets transmitted, 1 received, 0% packet loss/, 'Ping success summary');
+		$cmd->stdout_like(qr{^PING ::1 \(::1\) 56 data bytes
+64 bytes from ::1: icmp_seq=1 ttl=\d+ time=\d\.\d{3} ms
+
+--- ::1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time \d+ms
+rtt min/avg/max/mdev = \d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3}/\d+\.\d{3} ms$},
+'Entire ping output matched exactly');
+		} else {
+			$cmd->stderr_like(qr/cannot flood/i);
+			$cmd->stdout_like(qr/PING ::1/);
+			$cmd->stderr_like(qr/use -i 0\.002/);
+			$cmd->stderr_like(qr/.*ping: cannot flood, minimal interval for user must be >= 2 ms, use -i 0\.002 \(or higher\)/);
+		}
+	}
+}

--- a/test/tracepath/meson.build
+++ b/test/tracepath/meson.build
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2021 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021-2025 Petr Vorel <pvorel@suse.cz>
 
-cmd = tracepath
-cmd_name = 'tracepath '
-args = ['-V']
+message('Build directory is: ' + meson.current_build_dir())
 
-name = cmd_name + ' '.join(args)
-test(name, cmd, args : args)
+foreach t : ['tracepath-01-basic.t']
+  test(t, find_program(t), args: tracepath)
+endforeach

--- a/test/tracepath/tracepath-01-basic.t
+++ b/test/tracepath/tracepath-01-basic.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2025 Petr Vorel <pvorel@suse.cz>
+
+use Test::Command tests => 2;
+use Test::More;
+
+my $lib = File::Basename::dirname(Cwd::abs_path($0)) . '/../lib.pl';
+require "$lib";
+
+my $tracepath = get_cmd($ARGV[0] // 'tracepath');
+
+# -V
+{
+    my $cmd = Test::Command->new(cmd => "$tracepath -V");
+    $cmd->exit_is_num(0);
+	subtest 'output' => sub {
+		$cmd->stdout_like(qr/^tracepath from iputils /, 'Print version');
+		$cmd->stdout_like(qr/libcap: (yes|no), IDN: (yes|no), NLS: (yes|no), error.h: (yes|no), getrandom\(\): (yes|no), __fpending\(\): (yes|no)$/, 'Print config');
+	}
+}


### PR DESCRIPTION
Improve testing of tools' output.

Partly rewritten python test code to perl based Test::Command framework.  That allows to compare tools output, not just exit code and describes better the output. Also it can be run standalone (without meson).
    
Covered mostly ping (but still needs to be improved).
TODO: covert all python tests.
    
Optional parameter allows to pass binary to be tested (path to binary would be better, but it'd have to be two directories: builddir/:builddir/ping/).

ping-01-basics.t mocks getaddrinfo() code in ping.

Other changes:
* "error: Unify output of error() implementation with glibc" required to fix test output
* "meson-build-dist-man.sh: Skip tests on building doc"
