### PR TITLE
ping: Split JSON hostname and IP address

### DIFF
--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1703,7 +1703,7 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 			wrong_source = 1;
 		if (gather_statistics(rts, (uint8_t *)icp, sizeof(*icp), cc,
 				      ntohs(icp->un.echo.sequence),
-				      reply_ttl, csfailed, tv, pr_addr(rts, from, sizeof *from),
+				      reply_ttl, csfailed, tv, pr_addr_split(rts, from, sizeof *from),
 				      pr_echo_reply, rts->multicast, wrong_source)) {
 			fflush(stdout);
 			return 0;

--- a/ping/ping.c
+++ b/ping/ping.c
@@ -1790,6 +1790,45 @@ int ping4_parse_reply(struct ping_rts *rts, struct socket_st *sock,
 }
 
 /*
+ * _pr_addr_split --
+ *
+ * Return an ascii host address optionally with a hostname (separated).
+ */
+struct pr_addr _pr_addr_split(struct ping_rts *rts, void *sa,
+                           socklen_t salen, int resolve_name)
+{
+	static struct pr_addr out = {0};
+	static struct sockaddr_storage last_sa = {0};
+	static socklen_t last_salen = 0;
+
+	if (salen == last_salen && !memcmp(sa, &last_sa, salen))
+		return out;
+
+	memcpy(&last_sa, sa, (last_salen = salen));
+
+	rts->in_pr_addr = !setjmp(rts->pr_addr_jmp);
+
+	getnameinfo(sa, salen, out.addr, sizeof(out.addr), NULL, 0, getnameinfo_flags | NI_NUMERICHOST);
+	if (!rts->exiting && resolve_name && (rts->opt_force_lookup || !rts->opt_numeric))
+		getnameinfo(sa, salen, out.name, sizeof(out.name), NULL, 0, getnameinfo_flags);
+
+	rts->in_pr_addr = 0;
+
+	return out;
+}
+
+/*
+ * pr_addr_split --
+ *
+ * Return an ascii host address with a hostname (separated).
+ */
+struct pr_addr pr_addr_split(struct ping_rts *rts, void *sa,
+                           socklen_t salen)
+{
+	return _pr_addr_split(rts, sa, salen, 1);
+}
+
+/*
  * pr_addr --
  *
  * Return an ascii host address with reverse name resolution.
@@ -1804,7 +1843,6 @@ char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen)
  *
  * Return an ascii host address.  Reverse name resolution is not performed.
  */
-
 char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen)
 {
 	return _pr_addr(rts, sa, salen, 0);
@@ -1817,31 +1855,20 @@ char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen)
  */
 char *_pr_addr(struct ping_rts *rts, void *sa, socklen_t salen, int resolve_name)
 {
+	struct pr_addr out = _pr_addr_split(rts, sa, salen, resolve_name);
+	return pr_addr_format(&out);
+}
+
+char *pr_addr_format(struct pr_addr *out)
+{
 	static char buffer[4096] = "";
-	static struct sockaddr_storage last_sa = {0};
-	static socklen_t last_salen = 0;
-	char name[NI_MAXHOST] = "";
-	char address[NI_MAXHOST] = "";
 
-	if (salen == last_salen && !memcmp(sa, &last_sa, salen))
-		return buffer;
-
-	memcpy(&last_sa, sa, (last_salen = salen));
-
-	rts->in_pr_addr = !setjmp(rts->pr_addr_jmp);
-
-	getnameinfo(sa, salen, address, sizeof address, NULL, 0, getnameinfo_flags | NI_NUMERICHOST);
-	if (!rts->exiting && resolve_name && (rts->opt_force_lookup || !rts->opt_numeric))
-		getnameinfo(sa, salen, name, sizeof name, NULL, 0, getnameinfo_flags);
-
-	if (*name && strncmp(name, address, NI_MAXHOST))
-		snprintf(buffer, sizeof buffer, "%s (%s)", name, address);
+	if (*out->name && strncmp(out->name, out->addr, NI_MAXHOST))
+		snprintf(buffer, sizeof buffer, "%s (%s)", out->name, out->addr);
 	else
-		snprintf(buffer, sizeof buffer, "%s", address);
+		snprintf(buffer, sizeof buffer, "%s", out->addr);
 
-	rts->in_pr_addr = 0;
-
-	return (buffer);
+	return buffer;
 }
 
 void ping4_install_filter(struct ping_rts *rts, socket_st *sock)

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -413,8 +413,19 @@ static inline int disable_capability_admin(void)	{ return modify_capability(0); 
 #endif
 extern void drop_capabilities(void);
 
+/* store getnameinfo() results */
+struct pr_addr {
+	/* hostname (can be empty) */
+	char name[NI_MAXHOST];
+	/* ascii host address */
+	char addr[NI_MAXHOST];
+};
+
 char *pr_addr(struct ping_rts *rts, void *sa, socklen_t salen);
+struct pr_addr pr_addr_split(struct ping_rts *rts, void *sa, socklen_t salen);
 char *pr_raw_addr(struct ping_rts *rts, void *sa, socklen_t salen);
+char *pr_addr_format(struct pr_addr *out);
+
 char *str_interval(int interval);
 
 int is_ours(struct ping_rts *rts, socket_st *sock, uint16_t id);

--- a/ping/ping.h
+++ b/ping/ping.h
@@ -440,7 +440,7 @@ extern void status(struct ping_rts *rts);
 extern void common_options(int ch);
 extern int gather_statistics(struct ping_rts *rts, uint8_t *icmph, int icmplen,
 			     int cc, uint16_t seq, int hops,
-			     int csfailed, struct timeval *tv, char *from,
+			     int csfailed, struct timeval *tv, struct pr_addr out,
 			     void (*pr_reply)(struct ping_rts *rts, uint8_t *ptr, int cc), int multicast,
 			     int wrong_source);
 extern void print_timestamp(struct ping_rts *rts);

--- a/ping/ping6_common.c
+++ b/ping/ping6_common.c
@@ -859,7 +859,7 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 
 		if (gather_statistics(rts, (uint8_t *)icmph, sizeof(*icmph), cc,
 				      ntohs(icmph->icmp6_seq),
-				      hops, 0, tv, pr_addr(rts, from, sizeof *from),
+				      hops, 0, tv, pr_addr_split(rts, from, sizeof *from),
 				      pr_echo_reply,
 				      rts->multicast, wrong_source)) {
 			fflush(stdout);
@@ -872,7 +872,7 @@ int ping6_parse_reply(struct ping_rts *rts, socket_st *sock,
 			return 1;
 		if (gather_statistics(rts, (uint8_t *)icmph, sizeof(*icmph), cc,
 				      seq,
-				      hops, 0, tv, pr_addr(rts, from, sizeof *from),
+				      hops, 0, tv, pr_addr_split(rts, from, sizeof *from),
 				      pr_niquery_reply,
 				      rts->multicast, 0))
 			return 0;

--- a/ping/ping_common.c
+++ b/ping/ping_common.c
@@ -748,7 +748,7 @@ int main_loop(struct ping_rts *rts, ping_func_set_st *fset, socket_st *sock,
 
 int gather_statistics(struct ping_rts *rts, uint8_t *icmph, int icmplen,
 		      int cc, uint16_t seq, int hops,
-		      int csfailed, struct timeval *tv, char *from,
+		      int csfailed, struct timeval *tv, struct pr_addr out,
 		      void (*pr_reply)(struct ping_rts *rts, uint8_t *icmph, int cc), int multicast,
 		      int wrong_source)
 {
@@ -835,8 +835,12 @@ restamp:
 
 		print_timestamp(rts);
 		ping_print_int(rts, _("%d bytes "), "bytes", cc);
-		// TODO: split host IP address and name into separate attributes in JSON?
-		ping_print_str(rts, _("from %s:"), "host", from);
+
+		// TODO: move into ping/ping_output.c
+		if (rts->opt_json)
+			construct_json_host(rts, out.name, out.addr);
+		else
+			printf(_("from %s:"), pr_addr_format(&out));
 
 		if (pr_reply)
 			pr_reply(rts, icmph, cc);

--- a/ping/ping_json.c
+++ b/ping/ping_json.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright (c) 2024-2025 Georg Pfuetzenreuter <mail+ip@georg-pfuetzenreuter.net>
+ * Copyright (c) Iputils Project, 2026
  */
 
 #include "ping.h"
@@ -140,6 +141,32 @@ void construct_json(struct ping_rts *rts, enum PING_JSON_TYPE ptype, char *key, 
 	va_end(ap);
 }
 
+void construct_json_host(struct ping_rts *rts, char *rdns, char *ip)
+{
+	if (!rts->opt_json)
+		return;
+
+	if (*rts->json_packet.object)
+		json_continue(&rts->json_packet);
+	else
+		json_start_object(&rts->json_packet);
+
+	struct ping_json_buffer json_host;
+
+	json_start_object(&json_host);
+
+	json_kv_str_continue(&json_host, "arg", rts->hostname);
+	if (*rdns)
+		json_kv_str_continue(&json_host, "rdns", rdns);
+	json_kv_str(&json_host, "ip", ip);
+
+	json_kv_object(&rts->json_packet, "host", &json_host);
+
+	/* reset object for next */
+	*json_host.object = '\0';
+	json_host.size = 0;
+}
+
 void construct_json_statistics(struct ping_rts *rts, struct timespec tv, char *rttmin, char *rttavg, char *rttmax, char *rttmdev)
 {
 	if (!rts->opt_json)
@@ -150,7 +177,6 @@ void construct_json_statistics(struct ping_rts *rts, struct timespec tv, char *r
 	else
 		json_start_object(&rts->json_stats);
 
-	json_kv_str_continue(&rts->json_stats, "host", rts->hostname);
 	json_kv_int_continue(&rts->json_stats, "transmitted", rts->ntransmitted);
 	json_kv_int_continue(&rts->json_stats, "received", rts->nreceived);
 	json_kv_int_continue(&rts->json_stats, "duplicates", rts->nrepeats);

--- a/ping/ping_json.h
+++ b/ping/ping_json.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2024 Georg Pfuetzenreuter <mail+ip@georg-pfuetzenreuter.net>
+ * Copyright (c) Iputils Project, 2026
  */
 
 #ifndef IPUTILS_PING_JSON_H
@@ -22,6 +23,7 @@ struct ping_json_buffer {
 
 void construct_json(struct ping_rts *rts, enum PING_JSON_TYPE ptype, char *key, ...);
 void construct_json_error(struct ping_rts *rts, int errnum, char *errmsg);
+void construct_json_host(struct ping_rts *rts, char *rdns, char *ip);
 void construct_json_statistics(struct ping_rts *rts, struct timespec tv, char *rttmin, char *rttavg, char *rttmax, char *rttmdev);
 void construct_json_statistics_flood(struct ping_rts *rts, char *ipg, char *ewma);
 void print_json_packet(struct ping_rts *rts);


### PR DESCRIPTION
Previously hostname and IP were printed together in "host" key:

    {"bytes": 64, "host": "www.seznam.cz (77.75.77.222)", "seq": 1,
	"ttl": 55, "time": "11.0"}
    {"host": "seznam.cz", "transmitted": 1, "received": 1, "duplicates":
	0, "corrupted": 0, "errors": 0, "loss": 0, "time": 0, "rtt": {"min":
	"11.015", "avg": "11.015", "max": "11.015", "mdev": "0.000"}}

Now output has new array "host", with "arg", "cname" and "ip" keys, replacing the original "host" key:

    {"bytes": 64, "host": {"arg": "seznam.cz", "cname": "www.seznam.cz",
	"ip": "77.75.79.222"}, "seq": 1, "ttl": 55, "time": "11.4"}
    {"transmitted": 1, "received": 1, "duplicates": 0, "corrupted": 0,
	"errors": 0, "loss": 0, "time": 0, "rtt": {"min": "11.384", "avg":
	"11.384", "max": "11.384", "mdev": "0.000"}}

* `arg` - original argv[1] parameter (destination).
* `cname` - getaddrinfo() reverse DNS resolution (PTR lookup), NOTE: not added if empty due calling ping with `-n`
* `ip` - IPv4 or IPv6

That required rewrite handling hostname and reverse IP resolution. Previously were both hostname and IP address passed to gather_statistics() in a single string. Now function have both as separate parameters. That required adding new function set_cname_ip().

Fixes: https://github.com/iputils/iputils/issues/609

@iputils/maintainers @tacerus comments are welcome. I'm sure the implementation needs cleanup and better naming of functions and parameters.