### PR TITLE
tracepath: Distinguish non-IP address resolution failure from socket() call failure

### DIFF
--- a/tracepath.c
+++ b/tracepath.c
@@ -522,6 +522,10 @@ int main(int argc, char **argv)
 		ctl.targetlen = ctl.ai->ai_addrlen;
 		break;
 	}
+
+	if (ctl.socket_fd == 0)
+		error(1, 0, "getaddrinfo() results were not IPV4 or IPV6");
+
 	if (ctl.socket_fd < 0)
 		error(1, errno, "socket/connect");
 


### PR DESCRIPTION
tracepath: Distinguish non-IP address resolution failure from socket() call failure
Add an explicit check for ctl.socket_fd == 0 to handle the edge case where
getaddrinfo() returns only non-AF_INET/AF_INET6 address families.
In this scenario no socket() syscall is ever invoked, so avoid misleading users
with a generic "socket/connect failed" error message.

When socket_fd remains 0 after iterating all getaddrinfo results, output a
specific error indicating no valid IPv4/IPv6 addresses were resolved.
Preserve the existing socket_fd < 0 check for genuine socket() or connect()
system call errors with captured errno.

Signed-off-by: wangxiaomeng <wangxiaomeng@kylinos.cn>